### PR TITLE
Fix docstring typo in Job.get_retry_delay

### DIFF
--- a/plain-worker/plain/worker/jobs.py
+++ b/plain-worker/plain/worker/jobs.py
@@ -140,7 +140,7 @@ class Job(metaclass=JobType):
 
     def get_retry_delay(self, attempt: int) -> int:
         """
-        Calcluate a delay in seconds before the next retry attempt.
+        Calculate a delay in seconds before the next retry attempt.
 
         On the first retry, attempt will be 1.
         """


### PR DESCRIPTION
## Summary
- correct "Calcluate" to "Calculate" in `plain-worker/plain/worker/jobs.py`

## Testing
- `bash ./scripts/test` *(fails: No route to host)*