### PR TITLE
Fix typo in plain worker README

### DIFF
--- a/plain/plain/README.md
+++ b/plain/plain/README.md
@@ -31,7 +31,7 @@ The `plain` package includes everything you need to start handling web requests 
 - [plain.cache](/plain-cache/plain/cache/README.md) - A database-driven general purpose cache.
 - [plain.email](/plain-email/plain/email/README.md) - Send emails with SMTP or custom backends.
 - [plain.sessions](/plain-sessions/plain/sessions/README.md) - User sessions and cookies.
-- [plain.worker](/plain-worker/plain/worker/README.md) - Backgrounb jobs stored in the database.
+- [plain.worker](/plain-worker/plain/worker/README.md) - Background jobs stored in the database.
 - [plain.api](/plain-api/plain/api/README.md) - Build APIs with Plain views.
 
 ## Auth Packages


### PR DESCRIPTION
## Summary
- correct typo in `plain/plain/README.md`

## Testing
- `bash scripts/test` *(fails: No route to host)*