### PR TITLE
Simplify test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        package: ["plain", "plain-worker", "plain-flags", "plain-sessions", "plain-admin", "plain-oauth", "plain-models", "plain-api", "plain-elements"]
+
+    env:
+      PACKAGES: plain plain-worker plain-flags plain-sessions plain-admin plain-oauth plain-models plain-api plain-elements
 
     steps:
     - uses: actions/checkout@v4
@@ -17,8 +19,12 @@ jobs:
       uses: astral-sh/setup-uv@v2
     - name: Set up Python
       run: uv python install ${{ matrix.python-version }}
-    - working-directory: ${{ matrix.package }}/tests
-      run: uv run --isolated pytest
+    - name: Run tests
+      run: |
+        for package in $PACKAGES; do
+          echo "Testing $package"
+          (cd "$package/tests" && uv run --isolated pytest)
+        done
 
   lint:
     runs-on: ubuntu-latest

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 workflow=".github/workflows/test.yml"
-packages=$(awk -F'[][]' '/package:/ {gsub(/"|,/, "", $2); print $2}' $workflow)
+packages=$(grep 'PACKAGES:' "$workflow" | sed -E 's/^.*PACKAGES: *//')
 
 function bold {
     echo "\033[1m$1\033[0m"


### PR DESCRIPTION
## Summary
- only matrix on python version in test workflow
- collect packages inside workflow test step
- update `scripts/test` to read packages from workflow

## Testing
- `bash ./scripts/test` *(fails: No route to host)*