### PR TITLE
Use CliRunner in CLI tests

### DIFF
--- a/plain/tests/test_cli.py
+++ b/plain/tests/test_cli.py
@@ -1,11 +1,17 @@
-import subprocess
+from click.testing import CliRunner
+
+from plain.cli.core import cli
 
 
 def test_plain_cli_help():
-    output = subprocess.check_output(["plain", "--help"])
-    assert output.startswith(b"Usage: plain")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"], prog_name="plain")
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage: plain")
 
 
 def test_plain_cli_build():
-    output = subprocess.check_output(["plain", "build"])
-    assert b"Compiled 0 assets into 0 files" in output
+    runner = CliRunner()
+    result = runner.invoke(cli, ["build"], prog_name="plain")
+    assert result.exit_code == 0
+    assert "Compiled 0 assets into 0 files" in result.output


### PR DESCRIPTION
## Summary
- use `click.testing.CliRunner` for CLI tests
- invoke CLI with `prog_name='plain'`
- assert on CLI result output

## Testing
- `bash scripts/test`