### PR TITLE
Fix pytest warnings

### DIFF
--- a/plain-oauth/pyproject.toml
+++ b/plain-oauth/pyproject.toml
@@ -13,10 +13,7 @@ dependencies = [
     "requests>=2.0.0",
 ]
 
-[tool.pytest.ini_options]
-python_files = "tests.py test_*.py *_tests.py"
-PLAIN_SETTINGS_MODULE = "tests.settings"
-FAIL_INVALID_TEMPLATE_VARS = true
+
 
 [tool.uv]
 dev-dependencies = [


### PR DESCRIPTION
## Summary
- remove deprecated pytest options from `plain-oauth`

## Testing
- `./scripts/test`