### PR TITLE
Remove unused request_class attribute in WSGIHandler

### DIFF
--- a/plain/plain/internal/handlers/wsgi.py
+++ b/plain/plain/internal/handlers/wsgi.py
@@ -125,15 +125,13 @@ class WSGIRequest(HttpRequest):
 
 
 class WSGIHandler(base.BaseHandler):
-    request_class = WSGIRequest
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.load_middleware()
 
     def __call__(self, environ, start_response):
         signals.request_started.send(sender=self.__class__, environ=environ)
-        request = self.request_class(environ)
+        request = WSGIRequest(environ)
         response = self.get_response(request)
 
         response._handler_class = self.__class__


### PR DESCRIPTION
## Summary
- simplify WSGIHandler by using `WSGIRequest` directly

## Testing
- `./scripts/fix`
- `./scripts/test`
