### PR TITLE
Replace custom cached_property with built‑in

### DIFF
--- a/plain-admin/plain/admin/querystats/core.py
+++ b/plain-admin/plain/admin/querystats/core.py
@@ -2,10 +2,9 @@ import datetime
 import time
 import traceback
 from collections import Counter
+from functools import cached_property
 
 import sqlparse
-
-from plain.utils.functional import cached_property
 
 IGNORE_STACK_FILES = [
     "threading",

--- a/plain-email/plain/email/backends/smtp.py
+++ b/plain-email/plain/email/backends/smtp.py
@@ -3,9 +3,9 @@
 import smtplib
 import ssl
 import threading
+from functools import cached_property
 
 from plain.runtime import settings
-from plain.utils.functional import cached_property
 
 from ..backends.base import BaseEmailBackend
 from ..message import sanitize_address

--- a/plain-flags/plain/flags/flags.py
+++ b/plain-flags/plain/flags/flags.py
@@ -1,9 +1,9 @@
 import logging
+from functools import cached_property
 from typing import Any
 
 from plain.runtime import settings
 from plain.utils import timezone
-from plain.utils.functional import cached_property
 
 from . import exceptions
 from .utils import coerce_key

--- a/plain-models/plain/models/backends/base/base.py
+++ b/plain-models/plain/models/backends/base/base.py
@@ -8,6 +8,7 @@ import warnings
 import zoneinfo
 from collections import deque
 from contextlib import contextmanager
+from functools import cached_property
 
 from plain.models.backends import utils
 from plain.models.backends.base.validation import BaseDatabaseValidation
@@ -20,7 +21,6 @@ from plain.models.db import (
 )
 from plain.models.transaction import TransactionManagementError
 from plain.runtime import settings
-from plain.utils.functional import cached_property
 
 NO_DB_ALIAS = "__no_db__"
 RAN_DB_VERSION_CHECK = set()

--- a/plain-models/plain/models/backends/base/features.py
+++ b/plain-models/plain/models/backends/base/features.py
@@ -1,4 +1,4 @@
-from plain.utils.functional import cached_property
+from functools import cached_property
 
 
 class BaseDatabaseFeatures:

--- a/plain-models/plain/models/backends/mysql/base.py
+++ b/plain-models/plain/models/backends/mysql/base.py
@@ -4,11 +4,12 @@ MySQL database backend for Plain.
 Requires mysqlclient: https://pypi.org/project/mysqlclient/
 """
 
+from functools import cached_property
+
 from plain.exceptions import ImproperlyConfigured
 from plain.models.backends import utils as backend_utils
 from plain.models.backends.base.base import BaseDatabaseWrapper
 from plain.models.db import IntegrityError
-from plain.utils.functional import cached_property
 from plain.utils.regex_helper import _lazy_re_compile
 
 try:

--- a/plain-models/plain/models/backends/mysql/features.py
+++ b/plain-models/plain/models/backends/mysql/features.py
@@ -1,7 +1,7 @@
 import operator
+from functools import cached_property
 
 from plain.models.backends.base.features import BaseDatabaseFeatures
-from plain.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):

--- a/plain-models/plain/models/backends/postgresql/base.py
+++ b/plain-models/plain/models/backends/postgresql/base.py
@@ -1,7 +1,7 @@
 import threading
 import warnings
 from contextlib import contextmanager
-from functools import lru_cache
+from functools import cached_property, lru_cache
 
 import psycopg as Database
 from psycopg import IsolationLevel, adapt, adapters, sql
@@ -16,7 +16,6 @@ from plain.models.backends.base.base import BaseDatabaseWrapper
 from plain.models.backends.utils import CursorDebugWrapper as BaseCursorDebugWrapper
 from plain.models.db import DatabaseError as WrappedDatabaseError
 from plain.models.db import connections
-from plain.utils.functional import cached_property
 
 # Some of these import psycopg, so import them after checking if it's installed.
 from .client import DatabaseClient  # NOQA isort:skip

--- a/plain-models/plain/models/backends/sqlite3/features.py
+++ b/plain-models/plain/models/backends/sqlite3/features.py
@@ -1,9 +1,9 @@
 import operator
+from functools import cached_property
 
 from plain.models import transaction
 from plain.models.backends.base.features import BaseDatabaseFeatures
 from plain.models.db import OperationalError
-from plain.utils.functional import cached_property
 
 from .base import Database
 

--- a/plain-models/plain/models/backends/sqlite3/operations.py
+++ b/plain-models/plain/models/backends/sqlite3/operations.py
@@ -1,7 +1,7 @@
 import datetime
 import decimal
 import uuid
-from functools import lru_cache
+from functools import cached_property, lru_cache
 
 from plain import models
 from plain.exceptions import FieldError
@@ -11,7 +11,6 @@ from plain.models.db import DatabaseError, NotSupportedError
 from plain.models.expressions import Col
 from plain.utils import timezone
 from plain.utils.dateparse import parse_date, parse_datetime, parse_time
-from plain.utils.functional import cached_property
 
 
 class DatabaseOperations(BaseDatabaseOperations):

--- a/plain-models/plain/models/db.py
+++ b/plain-models/plain/models/db.py
@@ -1,11 +1,11 @@
 import pkgutil
+from functools import cached_property
 from importlib import import_module
 
 from plain import signals
 from plain.exceptions import ImproperlyConfigured
 from plain.runtime import settings
 from plain.utils.connection import BaseConnectionHandler, ConnectionProxy
-from plain.utils.functional import cached_property
 from plain.utils.module_loading import import_string
 
 DEFAULT_DB_ALIAS = "default"

--- a/plain-models/plain/models/expressions.py
+++ b/plain-models/plain/models/expressions.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 from collections import defaultdict
 from decimal import Decimal
+from functools import cached_property
 from types import NoneType
 from uuid import UUID
 
@@ -13,7 +14,6 @@ from plain.models.constants import LOOKUP_SEP
 from plain.models.db import DatabaseError, NotSupportedError, connection
 from plain.models.query_utils import Q
 from plain.utils.deconstruct import deconstructible
-from plain.utils.functional import cached_property
 from plain.utils.hashable import make_hashable
 
 

--- a/plain-models/plain/models/fields/__init__.py
+++ b/plain-models/plain/models/fields/__init__.py
@@ -6,7 +6,7 @@ import operator
 import uuid
 import warnings
 from base64 import b64decode, b64encode
-from functools import partialmethod, total_ordering
+from functools import cached_property, partialmethod, total_ordering
 
 from plain import exceptions, preflight, validators
 from plain.models.constants import LOOKUP_SEP
@@ -22,7 +22,7 @@ from plain.utils.dateparse import (
     parse_time,
 )
 from plain.utils.duration import duration_microseconds, duration_string
-from plain.utils.functional import Promise, cached_property
+from plain.utils.functional import Promise
 from plain.utils.ipv6 import clean_ipv6_address
 from plain.utils.itercompat import is_iterable
 

--- a/plain-models/plain/models/fields/related.py
+++ b/plain-models/plain/models/fields/related.py
@@ -1,6 +1,6 @@
 import functools
 import inspect
-from functools import partial
+from functools import cached_property, partial
 
 from plain import exceptions, preflight
 from plain.models.constants import LOOKUP_SEP
@@ -9,7 +9,6 @@ from plain.models.deletion import SET_DEFAULT, SET_NULL
 from plain.models.query_utils import PathInfo, Q
 from plain.models.utils import make_model_tuple
 from plain.runtime import SettingsReference, settings
-from plain.utils.functional import cached_property
 
 from ..registry import models_registry
 from . import Field

--- a/plain-models/plain/models/fields/related_descriptors.py
+++ b/plain-models/plain/models/fields/related_descriptors.py
@@ -46,6 +46,8 @@ reverse many-to-one relation.
    ``ReverseManyToManyDescriptor``, use ``ManyToManyDescriptor`` instead.
 """
 
+from functools import cached_property
+
 from plain.exceptions import FieldError
 from plain.models import transaction
 from plain.models.db import (
@@ -60,7 +62,6 @@ from plain.models.lookups import GreaterThan, LessThanOrEqual
 from plain.models.query import QuerySet
 from plain.models.query_utils import DeferredAttribute, Q
 from plain.models.utils import resolve_callables
-from plain.utils.functional import cached_property
 
 
 class ForeignKeyDeferredAttribute(DeferredAttribute):

--- a/plain-models/plain/models/fields/reverse_related.py
+++ b/plain-models/plain/models/fields/reverse_related.py
@@ -9,8 +9,9 @@ They also act as reverse fields for the purposes of the Meta API because
 they're the closest concept currently available.
 """
 
+from functools import cached_property
+
 from plain import exceptions
-from plain.utils.functional import cached_property
 from plain.utils.hashable import make_hashable
 
 from . import BLANK_CHOICE_DASH

--- a/plain-models/plain/models/lookups.py
+++ b/plain-models/plain/models/lookups.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+from functools import cached_property
 
 from plain.exceptions import EmptyResultSet, FullResultSet
 from plain.models.expressions import Expression, Func, Value
@@ -13,7 +14,6 @@ from plain.models.fields import (
 )
 from plain.models.query_utils import RegisterLookupMixin
 from plain.utils.datastructures import OrderedSet
-from plain.utils.functional import cached_property
 from plain.utils.hashable import make_hashable
 
 

--- a/plain-models/plain/models/migrations/operations/fields.py
+++ b/plain-models/plain/models/migrations/operations/fields.py
@@ -1,6 +1,7 @@
+from functools import cached_property
+
 from plain.models.fields import NOT_PROVIDED
 from plain.models.migrations.utils import field_references
-from plain.utils.functional import cached_property
 
 from .base import Operation
 

--- a/plain-models/plain/models/migrations/operations/models.py
+++ b/plain-models/plain/models/migrations/operations/models.py
@@ -1,8 +1,9 @@
+from functools import cached_property
+
 from plain import models
 from plain.models.migrations.operations.base import Operation
 from plain.models.migrations.state import ModelState
 from plain.models.migrations.utils import field_references, resolve_relation
-from plain.utils.functional import cached_property
 
 from .fields import AddField, AlterField, FieldOperation, RemoveField, RenameField
 

--- a/plain-models/plain/models/migrations/state.py
+++ b/plain-models/plain/models/migrations/state.py
@@ -1,7 +1,7 @@
 import copy
 from collections import defaultdict
 from contextlib import contextmanager
-from functools import partial
+from functools import cached_property, partial
 
 from plain import models
 from plain.exceptions import FieldDoesNotExist
@@ -12,7 +12,6 @@ from plain.models.options import DEFAULT_NAMES
 from plain.models.registry import ModelsRegistry
 from plain.models.registry import models_registry as global_models
 from plain.packages import packages_registry
-from plain.utils.functional import cached_property
 from plain.utils.module_loading import import_string
 
 from .exceptions import InvalidBasesError

--- a/plain-models/plain/models/options.py
+++ b/plain-models/plain/models/options.py
@@ -2,6 +2,7 @@ import bisect
 import copy
 import inspect
 from collections import defaultdict
+from functools import cached_property
 
 from plain.exceptions import FieldDoesNotExist
 from plain.models import models_registry
@@ -10,7 +11,6 @@ from plain.models.db import connections
 from plain.models.fields import BigAutoField
 from plain.models.manager import Manager
 from plain.utils.datastructures import ImmutableList
-from plain.utils.functional import cached_property
 
 PROXY_PARENTS = object()
 

--- a/plain-models/plain/models/query.py
+++ b/plain-models/plain/models/query.py
@@ -5,6 +5,7 @@ The main QuerySet implementation. This provides the public API for the ORM.
 import copy
 import operator
 import warnings
+from functools import cached_property
 from itertools import chain, islice
 
 import plain.runtime
@@ -37,7 +38,7 @@ from plain.models.utils import (
     resolve_callables,
 )
 from plain.utils import timezone
-from plain.utils.functional import cached_property, partition
+from plain.utils.functional import partition
 
 # The maximum number of results to fetch in a get() query.
 MAX_GET_RESULTS = 21

--- a/plain-models/plain/models/sql/compiler.py
+++ b/plain-models/plain/models/sql/compiler.py
@@ -1,7 +1,7 @@
 import collections
 import json
 import re
-from functools import partial
+from functools import cached_property, partial
 from itertools import chain
 
 from plain.exceptions import EmptyResultSet, FieldError, FullResultSet
@@ -22,7 +22,6 @@ from plain.models.sql.constants import (
 from plain.models.sql.query import Query, get_order_dir
 from plain.models.sql.where import AND
 from plain.models.transaction import TransactionManagementError
-from plain.utils.functional import cached_property
 from plain.utils.hashable import make_hashable
 from plain.utils.regex_helper import _lazy_re_compile
 

--- a/plain-models/plain/models/sql/query.py
+++ b/plain-models/plain/models/sql/query.py
@@ -13,6 +13,7 @@ import functools
 import sys
 from collections import Counter, namedtuple
 from collections.abc import Iterator, Mapping
+from functools import cached_property
 from itertools import chain, count, product
 from string import ascii_uppercase
 
@@ -41,7 +42,6 @@ from plain.models.query_utils import (
 from plain.models.sql.constants import INNER, LOUTER, ORDER_DIR, SINGLE
 from plain.models.sql.datastructures import BaseTable, Empty, Join, MultiJoin
 from plain.models.sql.where import AND, OR, ExtraWhere, NothingNode, WhereNode
-from plain.utils.functional import cached_property
 from plain.utils.regex_helper import _lazy_re_compile
 from plain.utils.tree import Node
 

--- a/plain-models/plain/models/sql/where.py
+++ b/plain-models/plain/models/sql/where.py
@@ -3,13 +3,12 @@ Code to manage the creation and SQL rendering of 'where' constraints.
 """
 
 import operator
-from functools import reduce
+from functools import cached_property, reduce
 
 from plain.exceptions import EmptyResultSet, FullResultSet
 from plain.models.expressions import Case, When
 from plain.models.lookups import Exact
 from plain.utils import tree
-from plain.utils.functional import cached_property
 
 # Connection types
 AND = "AND"

--- a/plain-pages/plain/pages/pages.py
+++ b/plain-pages/plain/pages/pages.py
@@ -1,9 +1,9 @@
 import os
+from functools import cached_property
 
 import frontmatter
 
 from plain.templates import Template
-from plain.utils.functional import cached_property
 
 from .markdown import render_markdown
 

--- a/plain-pages/plain/pages/views.py
+++ b/plain-pages/plain/pages/views.py
@@ -1,6 +1,7 @@
+from functools import cached_property
+
 from plain.assets.views import AssetView
 from plain.http import Http404, ResponsePermanentRedirect, ResponseRedirect
-from plain.utils.functional import cached_property
 from plain.views import TemplateView, View
 
 from .exceptions import PageNotFoundError, RedirectPageError

--- a/plain-passwords/plain/passwords/validators.py
+++ b/plain-passwords/plain/passwords/validators.py
@@ -1,11 +1,11 @@
 import gzip
+from functools import cached_property
 from pathlib import Path
 
 from plain.exceptions import (
     ValidationError,
 )
 from plain.utils.deconstruct import deconstructible
-from plain.utils.functional import cached_property
 from plain.utils.text import pluralize
 
 

--- a/plain/plain/csrf/middleware.py
+++ b/plain/plain/csrf/middleware.py
@@ -8,6 +8,7 @@ against request forgeries from other sites.
 import logging
 import string
 from collections import defaultdict
+from functools import cached_property
 from urllib.parse import urlparse
 
 from plain.exceptions import DisallowedHost
@@ -16,7 +17,6 @@ from plain.logs import log_response
 from plain.runtime import settings
 from plain.utils.cache import patch_vary_headers
 from plain.utils.crypto import constant_time_compare, get_random_string
-from plain.utils.functional import cached_property
 from plain.utils.http import is_same_domain
 from plain.utils.regex_helper import _lazy_re_compile
 

--- a/plain/plain/forms/forms.py
+++ b/plain/plain/forms/forms.py
@@ -3,9 +3,9 @@ Form classes
 """
 
 import copy
+from functools import cached_property
 
 from plain.exceptions import NON_FIELD_ERRORS
-from plain.utils.functional import cached_property
 
 from .exceptions import ValidationError
 from .fields import Field, FileField

--- a/plain/plain/http/request.py
+++ b/plain/plain/http/request.py
@@ -2,6 +2,7 @@ import codecs
 import copy
 import json
 import uuid
+from functools import cached_property
 from io import BytesIO
 from itertools import chain
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlsplit
@@ -25,7 +26,6 @@ from plain.utils.datastructures import (
     MultiValueDict,
 )
 from plain.utils.encoding import iri_to_uri
-from plain.utils.functional import cached_property
 from plain.utils.http import is_same_domain, parse_header_parameters
 from plain.utils.regex_helper import _lazy_re_compile
 

--- a/plain/plain/internal/files/base.py
+++ b/plain/plain/internal/files/base.py
@@ -1,8 +1,8 @@
 import os
+from functools import cached_property
 from io import UnsupportedOperation
 
 from plain.internal.files.utils import FileProxyMixin
-from plain.utils.functional import cached_property
 
 
 class File(FileProxyMixin):

--- a/plain/plain/internal/handlers/wsgi.py
+++ b/plain/plain/internal/handlers/wsgi.py
@@ -1,11 +1,11 @@
 import uuid
+from functools import cached_property
 from io import IOBase
 from urllib.parse import quote
 
 from plain import signals
 from plain.http import HttpRequest, QueryDict, parse_cookie
 from plain.internal.handlers import base
-from plain.utils.functional import cached_property
 from plain.utils.regex_helper import _lazy_re_compile
 
 _slashes_re = _lazy_re_compile(rb"/+")

--- a/plain/plain/paginator.py
+++ b/plain/plain/paginator.py
@@ -1,9 +1,9 @@
 import collections.abc
 import inspect
 import warnings
+from functools import cached_property
 from math import ceil
 
-from plain.utils.functional import cached_property
 from plain.utils.inspect import method_has_no_args
 
 

--- a/plain/plain/utils/connection.py
+++ b/plain/plain/utils/connection.py
@@ -1,7 +1,7 @@
+from functools import cached_property
 from threading import local
 
 from plain.runtime import settings as plain_settings
-from plain.utils.functional import cached_property
 
 
 class ConnectionProxy:

--- a/plain/plain/utils/functional.py
+++ b/plain/plain/utils/functional.py
@@ -4,49 +4,6 @@ import operator
 from functools import total_ordering, wraps
 
 
-class cached_property:
-    """
-    Decorator that converts a method with a single self argument into a
-    property cached on the instance.
-
-    A cached property can be made out of an existing method:
-    (e.g. ``url = cached_property(get_absolute_url)``).
-    """
-
-    name = None
-
-    @staticmethod
-    def func(instance):
-        raise TypeError(
-            "Cannot use cached_property instance without calling __set_name__() on it."
-        )
-
-    def __init__(self, func):
-        self.real_func = func
-        self.__doc__ = getattr(func, "__doc__")
-
-    def __set_name__(self, owner, name):
-        if self.name is None:
-            self.name = name
-            self.func = self.real_func
-        elif name != self.name:
-            raise TypeError(
-                "Cannot assign the same cached_property to two different names "
-                f"({self.name!r} and {name!r})."
-            )
-
-    def __get__(self, instance, cls=None):
-        """
-        Call the function and put the return value in instance.__dict__ so that
-        subsequent attribute access on the instance returns the cached value
-        instead of calling cached_property.__get__().
-        """
-        if instance is None:
-            return self
-        res = instance.__dict__[self.name] = self.func(instance)
-        return res
-
-
 class classproperty:
     """
     Decorator that converts a method with a single cls argument into a property


### PR DESCRIPTION
## Summary
- drop custom `cached_property` implementation
- use `functools.cached_property` everywhere

## Testing
- `./scripts/test`