### PR TITLE
Enforce exclusive use of db fixtures

### DIFF
--- a/plain-models/plain/models/test/pytest.py
+++ b/plain-models/plain/models/test/pytest.py
@@ -57,7 +57,9 @@ def setup_db(request):
 
 
 @pytest.fixture
-def db(setup_db):
+def db(setup_db, request):
+    if "isolated_db" in request.fixturenames:
+        pytest.fail("The 'db' and 'isolated_db' fixtures cannot be used together")
     # Set .cursor() back to the original implementation to unblock it
     BaseDatabaseWrapper.cursor = BaseDatabaseWrapper._enabled_cursor
 
@@ -101,6 +103,8 @@ def isolated_db(request):
     derived from the test function name to ensure isolation from the default
     test database.
     """
+    if "db" in request.fixturenames:
+        pytest.fail("The 'db' and 'isolated_db' fixtures cannot be used together")
     # Set .cursor() back to the original implementation to unblock it
     BaseDatabaseWrapper.cursor = BaseDatabaseWrapper._enabled_cursor
 


### PR DESCRIPTION
## Summary
- prevent using `db` and `isolated_db` pytest fixtures at the same time

## Testing
- `./scripts/test plain-models`


------
https://chatgpt.com/codex/tasks/task_e_684659739de0832c8619c43ca7d7ffd5