### PR TITLE
fix: resolve security and code quality issues

### DIFF
--- a/plain-admin/plain/admin/impersonate/views.py
+++ b/plain-admin/plain/admin/impersonate/views.py
@@ -3,19 +3,32 @@ from plain.http import RedirectResponse, Response
 from plain.sessions.views import SessionView
 
 from .constants import _IMPERSONATE_SESSION_KEY
-from .permissions import can_be_impersonator
+from .permissions import can_be_impersonator, can_impersonate_user
 from .requests import get_request_impersonator
 
 
 class ImpersonateStartView(AuthView):
     def get(self) -> Response:
+        from app.users.models import User
+
         # We *could* already be impersonating, so need to consider that
         impersonator = get_request_impersonator(self.request) or self.user
-        if impersonator and can_be_impersonator(impersonator):
-            self.session[_IMPERSONATE_SESSION_KEY] = self.url_kwargs["id"]
-            return RedirectResponse(self.request.query_params.get("next", "/"))
+        target_id = self.url_kwargs["id"]
 
-        return Response(status_code=403)
+        if not (impersonator and can_be_impersonator(impersonator)):
+            return Response(status_code=403)
+
+        # Validate that the target user exists and can be impersonated
+        try:
+            target_user = User.query.get(id=target_id)
+        except User.DoesNotExist:
+            return Response(status_code=404)
+
+        if not can_impersonate_user(impersonator, target_user):
+            return Response(status_code=403)
+
+        self.session[_IMPERSONATE_SESSION_KEY] = target_id
+        return RedirectResponse(self.request.query_params.get("next", "/"))
 
 
 class ImpersonateStopView(SessionView):

--- a/plain-dev/plain/dev/backups/core.py
+++ b/plain-dev/plain/dev/backups/core.py
@@ -69,7 +69,9 @@ class DatabaseBackups:
         try:
             self.prune()
         except Exception:
-            pass
+            import logging
+
+            logging.getLogger(__name__).exception("Failed to prune backups")
         return backup_dir
 
     def prune(self) -> list[str]:

--- a/plain-postgres/plain/postgres/connection.py
+++ b/plain-postgres/plain/postgres/connection.py
@@ -1220,6 +1220,7 @@ class DatabaseConnection:
                 self._execute_create_test_db(cursor, test_db_params)
             except Exception as e:
                 self._log(f"Got an error creating the test database: {e}")
+                confirm = ""
                 if not autoclobber:
                     confirm = input(
                         "Type 'yes' if you would like to try deleting the test "

--- a/plain/plain/cli/shell.py
+++ b/plain/plain/cli/shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import sys
 
@@ -67,7 +68,7 @@ def shell(interface: str | None, command: str | None) -> None:
 def run(script: str) -> None:
     """Execute Python scripts with app context"""
     before_script = "import plain.runtime; plain.runtime.setup()"
-    command = f"{before_script}; exec(open('{script}').read())"
+    command = f"{before_script}; exec(open({shlex.quote(script)}).read())"
     result = subprocess.run(["python", "-c", command])
     if result.returncode:
         sys.exit(result.returncode)

--- a/plain/plain/http/request.py
+++ b/plain/plain/http/request.py
@@ -67,6 +67,7 @@ class Request:
         path_info: str = "",
     ):
         self.unique_id = str(uuid.uuid4())
+        self._read_started = False
         self.resolver_match: ResolverMatch | None = None
 
         self.method = method

--- a/plain/plain/utils/html.py
+++ b/plain/plain/utils/html.py
@@ -53,8 +53,8 @@ def json_script(
     json_str = json.dumps(value, cls=encoder or PlainJSONEncoder).translate(
         _json_script_escapes
     )
-    id_attr = f' id="{element_id}"' if element_id else ""
-    nonce_attr = f' nonce="{nonce}"' if nonce else ""
+    id_attr = f' id="{escape(element_id)}"' if element_id else ""
+    nonce_attr = f' nonce="{escape(nonce)}"' if nonce else ""
     return mark_safe(
         f'<script{id_attr}{nonce_attr} type="application/json">{json_str}</script>'
     )


### PR DESCRIPTION
## Summary

This PR fixes several security and code quality issues found during a codebase audit of the Plain framework:

### Security Fixes

- **Fix impersonation bypass** (`plain-admin/plain/admin/impersonate/views.py`) — `ImpersonateStartView` was only checking `can_be_impersonator()` but not `can_impersonate_user()`. This meant an admin could set any user ID (including other admins) as the impersonation target in the session. The middleware later checks `can_impersonate_user`, but by then the target ID is already persisted in the session. The view now resolves the target user and validates `can_impersonate_user()` before setting the session key, returning 404 if the user doesn't exist and 403 if impersonation is not allowed.

- **Fix HTML attribute injection in `json_script()`** (`plain/plain/utils/html.py`) — `element_id` and `nonce` parameters were interpolated into HTML attributes without escaping. If user-controlled data was passed as `element_id`, it could result in attribute injection (e.g., breaking out of the attribute with `"`). Now uses `escape()` to sanitize.

- **Fix shell injection in `plain run` command** (`plain/plain/cli/shell.py`) — The script file path was interpolated into a shell command string without escaping. A path containing shell metacharacters (spaces, quotes, backticks) could lead to unexpected behavior. Now uses `shlex.quote()` to safely escape the path.

### Bug Fixes

- **Fix uninitialized `_read_started` in `Request.__init__`** (`plain/plain/http/request.py`) — `_read_started` was only set to `True` in `read()`/`readline()` but never initialized to `False` in `__init__`. Accessing `body` before any read call would raise `AttributeError` instead of the expected `RawPostDataException`.

### Code Quality

- **Replace silent exception swallowing with logging** (`plain-dev/plain/dev/backups/core.py`) — Backup pruning used `except Exception: pass`, silently hiding disk-full errors, permission issues, and corruption. Now logs the exception for debugging.

- **Fix potential `UnboundLocalError`** (`plain-postgres/plain/postgres/connection.py`) — The `confirm` variable in `_create_test_db` was only assigned inside a conditional branch but referenced unconditionally in the `except` block. While the short-circuit evaluation of `autoclobber or confirm == "yes"` makes this safe in practice, initializing `confirm = ""` makes the intent clear and satisfies linters.

## Test plan

- [ ] Verify impersonation flow still works for valid admin→non-admin impersonation
- [ ] Verify impersonation is rejected when targeting an admin user (403)
- [ ] Verify impersonation returns 404 for non-existent user IDs
- [ ] Test `json_script()` with special characters in `element_id` (e.g., `"><script>alert(1)</script>`)
- [ ] Test `plain run` with script paths containing spaces or special characters
- [ ] Verify `Request.body` works correctly for normal requests and raises `RawPostDataException` (not `AttributeError`) when accessed after `read()`
- [ ] Run existing test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)