### PR TITLE
Raise FieldError instead of AssertionError for unresolved lookups in Q.check

### DIFF
--- a/plain-postgres/plain/postgres/sql/query.py
+++ b/plain-postgres/plain/postgres/sql/query.py
@@ -1221,7 +1221,8 @@ class Query(BaseExpression):
                 if summarize:
                     expression = Ref(annotation, expression)
                 return expression_lookups, (), expression
-        assert self.model is not None, "Field lookups require a model"
+        if self.model is None:
+            raise FieldError("Field lookups require a model")
         meta = self.model._model_meta
         _, field, _, lookup_parts = self.names_to_path(lookup_splitted, meta)
         field_parts = lookup_splitted[0 : len(lookup_splitted) - len(lookup_parts)]

--- a/plain-postgres/tests/test_check_constraint_choices_regex_68.py
+++ b/plain-postgres/tests/test_check_constraint_choices_regex_68.py
@@ -1,0 +1,30 @@
+"""Regression test for issue #68.
+
+A CheckConstraint whose Q references a field that has been excluded from
+``against`` (e.g. because ``clean_fields`` already produced a choices
+``ValidationError`` for it and ``full_clean`` adds it to ``exclude``)
+must not crash with an ``AssertionError`` from inside ``Q.check()``.
+The existing ``except FieldError`` branch in ``CheckConstraint.validate``
+should swallow the unresolvable lookup, matching the historical behavior.
+"""
+
+from __future__ import annotations
+
+from app.examples.models.constraints import ConstraintExample
+
+from plain.postgres import CheckConstraint, Q
+
+
+def test_check_constraint_validate_skips_when_field_excluded(db: None) -> None:
+    """Q references the excluded field 'name' — Q.check() must not assert."""
+    constraint = CheckConstraint(
+        check=Q(name__regex=r"^ok-(a|b)$"),
+        name="name_regex_excluded_field",
+    )
+    instance = ConstraintExample(name="bogus", description="d")
+
+    # Excluding the constrained field exercises the path where ``against``
+    # is missing the alias the Q references. Pre-fix, this crashed with
+    # ``AssertionError: Field lookups require a model``. Post-fix, the
+    # ``FieldError`` is caught and validate() returns silently.
+    constraint.validate(ConstraintExample, instance, exclude={"name"})


### PR DESCRIPTION
Fixes #68.

`CheckConstraint.validate` catches `FieldError` from `Q.check()` to skip client-side validation when the field map (`against`) is missing a field that the constraint's Q references. `Query.solve_lookup_type` was raising a bare `AssertionError` instead of `FieldError` when the Query has no model and no annotation matches the lookup, so the catch was bypassed and `full_clean()` crashed.

This happens in the issue's reproducer because `full_clean()` adds the field to `exclude` after `clean_fields` raises a choices `ValidationError`, then runs `validate_constraints` with the field absent from `against`.

Changing the assert to `raise FieldError` restores the intended fall-through and matches the historical Django behavior the existing `except FieldError: pass` was written for.

Includes a regression test that covers the excluded-field path.