### PR TITLE
Redirect already-logged-in users from login page safely

### DIFF
--- a/plain-loginlink/plain/loginlink/views.py
+++ b/plain-loginlink/plain/loginlink/views.py
@@ -25,8 +25,7 @@ class LoginLinkFormView(AuthView, FormView[LoginLinkForm]):
 
     def get(self) -> Response:
         # Redirect if the user is already logged in. The form is never
-        # validated on a GET (no cleaned_data), so "next" comes straight
-        # from the query string, like LoginLinkSentView.
+        # validated on a GET, so "next" comes from the query string.
         if self.user:
             return RedirectResponse(self.request.query_params.get("next", "/"))
 

--- a/plain-loginlink/plain/loginlink/views.py
+++ b/plain-loginlink/plain/loginlink/views.py
@@ -24,10 +24,11 @@ class LoginLinkFormView(AuthView, FormView[LoginLinkForm]):
     success_url = reverse_lazy("loginlink:sent")
 
     def get(self) -> Response:
-        # Redirect if the user is already logged in
+        # Redirect if the user is already logged in. The form is never
+        # validated on a GET (no cleaned_data), so "next" comes straight
+        # from the query string, like LoginLinkSentView.
         if self.user:
-            form = self.get_form()
-            return RedirectResponse(self.get_success_url(form))
+            return RedirectResponse(self.request.query_params.get("next", "/"))
 
         return super().get()
 

--- a/plain-loginlink/plain/loginlink/views.py
+++ b/plain-loginlink/plain/loginlink/views.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from plain.auth import login, logout
 from plain.auth.views import AuthView
@@ -18,6 +18,19 @@ from .links import (
     get_link_token_user,
 )
 
+if TYPE_CHECKING:
+    from plain.http import Request
+
+
+def redirect_to_next_url(request: Request, default: str = "/") -> RedirectResponse:
+    """Redirect to the "next" query param, or the default when it's missing,
+    empty, or an external URL (which RedirectResponse refuses)."""
+    next_url = request.query_params.get("next") or default
+    try:
+        return RedirectResponse(next_url)
+    except ValueError:
+        return RedirectResponse(default)
+
 
 class LoginLinkFormView(AuthView, FormView[LoginLinkForm]):
     form_class = LoginLinkForm
@@ -27,7 +40,7 @@ class LoginLinkFormView(AuthView, FormView[LoginLinkForm]):
         # Redirect if the user is already logged in. The form is never
         # validated on a GET, so "next" comes from the query string.
         if self.user:
-            return RedirectResponse(self.request.query_params.get("next", "/"))
+            return redirect_to_next_url(self.request)
 
         return super().get()
 
@@ -50,7 +63,7 @@ class LoginLinkSentView(AuthView, TemplateView):
     def get(self) -> Response:
         # Redirect if the user is already logged in
         if self.user:
-            return RedirectResponse(self.request.query_params.get("next", "/"))
+            return redirect_to_next_url(self.request)
 
         return super().get()
 
@@ -86,7 +99,4 @@ class LoginLinkLoginView(AuthView, View):
 
         login(self.request, user)
 
-        if next_url := self.request.query_params.get("next"):
-            return RedirectResponse(next_url)
-
-        return RedirectResponse(self.success_url)
+        return redirect_to_next_url(self.request, default=self.success_url)

--- a/plain-loginlink/tests/public/test_loginlink.py
+++ b/plain-loginlink/tests/public/test_loginlink.py
@@ -62,6 +62,26 @@ class TestRequestLink:
         assert len(mailoutbox) == 0
 
 
+class TestAlreadyLoggedIn:
+    def test_login_page_redirects_home(self, db):
+        client = Client()
+        client.force_login(User.query.create(email="repeat@example.com"))
+
+        response = client.get("/login")
+
+        assert response.status_code == 302
+        assert response.url == "/"
+
+    def test_login_page_redirects_to_next(self, db):
+        client = Client()
+        client.force_login(User.query.create(email="repeat@example.com"))
+
+        response = client.get("/login?next=/whoami")
+
+        assert response.status_code == 302
+        assert response.url == "/whoami"
+
+
 class TestFollowLink:
     def test_valid_link_logs_in(self, db, mailoutbox):
         User.query.create(email="follow@example.com")

--- a/plain-loginlink/tests/public/test_loginlink.py
+++ b/plain-loginlink/tests/public/test_loginlink.py
@@ -81,6 +81,26 @@ class TestAlreadyLoggedIn:
         assert response.status_code == 302
         assert response.url == "/whoami"
 
+    def test_empty_next_redirects_home(self, db):
+        client = Client()
+        client.force_login(User.query.create(email="repeat@example.com"))
+
+        response = client.get("/login?next=")
+
+        # An empty Location header would redirect the browser back to
+        # the login page in a loop.
+        assert response.status_code == 302
+        assert response.url == "/"
+
+    def test_external_next_redirects_home(self, db):
+        client = Client()
+        client.force_login(User.query.create(email="repeat@example.com"))
+
+        response = client.get("/login?next=https://evil.com")
+
+        assert response.status_code == 302
+        assert response.url == "/"
+
 
 class TestFollowLink:
     def test_valid_link_logs_in(self, db, mailoutbox):


### PR DESCRIPTION
## Summary

When an already-logged-in user visits the login page, they are now redirected safely using a new `redirect_to_next_url()` helper function that validates the redirect target and prevents open redirect vulnerabilities.

## Changes

- **Added `redirect_to_next_url()` helper function** in `views.py` that:
  - Redirects to the `next` query parameter if present and valid
  - Falls back to a default URL (typically `/`) for missing, empty, or external URLs
  - Catches `ValueError` from `RedirectResponse` to handle invalid external URLs safely

- **Updated `LoginLinkFormView.get()`** to use the new helper when redirecting already-logged-in users, removing the previous form-based redirect logic

- **Updated `LoginLinkSentView.get()`** to use the new helper for consistency

- **Updated `FollowLinkView.get()`** to use the new helper with a custom default URL

- **Added comprehensive test coverage** in `TestAlreadyLoggedIn` class with four test cases:
  - Redirect to home when no `next` parameter
  - Redirect to `next` parameter when valid
  - Redirect to home when `next` is empty
  - Redirect to home when `next` is an external URL (security check)

## Implementation Details

The helper function uses a try/except pattern to handle `RedirectResponse`'s built-in validation, which raises `ValueError` for external URLs. This provides defense-in-depth against open redirect vulnerabilities while keeping the code simple and maintainable.

https://claude.ai/code/session_01H1ZivVXdALbLRZT7sCwtt8