### PR TITLE
Clear stale rollback_exc across transactions

### DIFF
--- a/plain-postgres/plain/postgres/transaction.py
+++ b/plain-postgres/plain/postgres/transaction.py
@@ -106,8 +106,12 @@ class Atomic(ContextDecorator):
                 "A durable atomic block cannot be nested within another atomic block."
             )
         if not conn.in_atomic_block:
-            # Reset state when entering an outermost atomic block.
+            # Reset state when entering an outermost atomic block. Clearing
+            # rollback_exc keeps a stale value from the reused connection wrapper
+            # from being misattributed as the cause of a later block's
+            # broken-transaction error.
             conn.needs_rollback = False
+            conn.rollback_exc = None
         if conn.in_atomic_block:
             # We're already in a transaction; create a savepoint, unless we
             # were told not to or we're already waiting for a rollback. The
@@ -181,6 +185,13 @@ class Atomic(ContextDecorator):
                     # otherwise.
                     if sid is None:
                         conn.needs_rollback = True
+                        # Record what broke the transaction (when we can see it)
+                        # so validate_no_broken_transaction() chains from the
+                        # real cause rather than a stale or absent one. Mirror
+                        # mark_for_rollback_on_error() and only capture Exception
+                        # (not BaseException like KeyboardInterrupt/SystemExit).
+                        if isinstance(exc_value, Exception):
+                            conn.rollback_exc = exc_value
                     else:
                         try:
                             conn.savepoint_rollback(sid)

--- a/plain-postgres/tests/internal/test_rollback_exc_attribution.py
+++ b/plain-postgres/tests/internal/test_rollback_exc_attribution.py
@@ -1,0 +1,85 @@
+"""Regression test for stale `rollback_exc` attribution across transactions.
+
+`connection.rollback_exc` records the exception behind a pending rollback so
+`validate_no_broken_transaction()` can chain a `TransactionManagementError`
+`from` it. The wrapper holding it is reused across `atomic()` blocks, so it
+must not survive the transaction that set it — otherwise a later broken
+transaction chains `from` a previous, unrelated transaction's exception.
+
+It's now cleared on entry to an outermost `atomic()` block, and the real cause
+is recorded when a savepoint-less nested block marks the transaction for
+rollback.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from plain.postgres import transaction
+from plain.postgres.db import get_connection
+
+
+def _execute(sql: str) -> None:
+    with get_connection().cursor() as cursor:
+        cursor.execute(sql)
+
+
+def _fail_in_savepoint_via_mark(sql: str) -> None:
+    """Mimic Model.create()/update(): a query that fails inside a savepoint,
+    routed through mark_for_rollback_on_error() so rollback_exc is set."""
+    with transaction.atomic():  # savepoint
+        with transaction.mark_for_rollback_on_error():
+            _execute(sql)
+
+
+def _fail_in_savepointless_block(sql: str) -> None:
+    """A failure inside a savepoint-less nested block, which marks the whole
+    transaction for rollback without a savepoint to roll back to."""
+    with transaction.atomic(savepoint=False):
+        _execute(sql)
+
+
+class TestRollbackExcAttribution:
+    def test_broken_transaction_not_attributed_to_prior_transaction(self, isolated_db):
+        conn = get_connection()
+
+        # Transaction 1: a caught failure through the Model.create()/update()
+        # path sets rollback_exc, which is not cleared when the block ends.
+        with transaction.atomic():
+            with pytest.raises(psycopg.errors.UndefinedTable):
+                _fail_in_savepoint_via_mark("SELECT * FROM txn1_missing_table")
+
+        # rollback_exc lingers on the reused wrapper until the next outermost
+        # atomic() block clears it (documents the leak this test guards).
+        assert conn.rollback_exc is not None
+        assert "txn1_missing_table" in str(conn.rollback_exc)
+
+        # Transaction 2: unrelated work that breaks the transaction via a
+        # savepoint-less nested block, then runs another query.
+        with transaction.atomic():
+            with pytest.raises(psycopg.errors.UndefinedTable):
+                _fail_in_savepointless_block("SELECT * FROM txn2_missing_table")
+
+            with pytest.raises(transaction.TransactionManagementError) as excinfo:
+                _execute("SELECT 1")
+
+        cause = excinfo.value.__cause__
+        # The regression: the cause must not be transaction 1's exception.
+        assert "txn1_missing_table" not in str(cause)
+        # And it should be transaction 2's actual failure.
+        assert cause is not None
+        assert "txn2_missing_table" in str(cause)
+
+    def test_clean_outermost_atomic_starts_without_a_cause(self, isolated_db):
+        conn = get_connection()
+
+        # Leave a stale rollback_exc behind, as transaction 1 above does.
+        with transaction.atomic():
+            with pytest.raises(psycopg.errors.UndefinedTable):
+                _fail_in_savepoint_via_mark("SELECT * FROM stale_table")
+        assert conn.rollback_exc is not None
+
+        # Entering a fresh outermost block clears it.
+        with transaction.atomic():
+            assert conn.rollback_exc is None


### PR DESCRIPTION
## Summary

`connection.rollback_exc` records the exception behind a pending rollback so `validate_no_broken_transaction()` can chain a `TransactionManagementError` `from` it. The `DatabaseConnection` **wrapper** holding it is reused across `atomic()` blocks — it lives in a ContextVar, and `close()`/pool-release only null the underlying psycopg connection, never `rollback_exc`. But `rollback_exc` was only ever *set* (in `mark_for_rollback_on_error()`) and **never cleared**.

So after one transaction routes a caught failure through that path — e.g. a `Model.create()`/`update()` that hits a unique/check constraint and is caught — the stale exception lingers on the wrapper. A later, unrelated transaction that trips `needs_rollback` via a path that doesn't set a fresh cause (a savepoint-less nested block, or `set_rollback(True)`) then raises `TransactionManagementError(...) from <the previous transaction's exception>` — a misleading `__cause__` pointing at a completely different unit of work (potentially a different request or job on the same pooled connection).

Severity is low — diagnostics only; control flow, rollback behavior, and query results are all unaffected — but a `__cause__` that points at the wrong transaction sends you chasing the wrong root cause during incident debugging.

## Fix

`plain-postgres/plain/postgres/transaction.py`:

1. **`Atomic.__enter__`** — clear `rollback_exc` when entering an outermost `atomic()` block, alongside the existing `needs_rollback = False` reset. Every new top-level transaction passes through this single choke point, and `rollback_exc` is only ever *read* while `needs_rollback` is True, so clearing them together leaves no observable window for a stale value.
2. **`Atomic.__exit__`** — when a savepoint-less nested block marks the transaction for rollback, record the actual `exc_value` as the cause, guarded by `isinstance(exc_value, Exception)` (mirroring `mark_for_rollback_on_error`'s `except Exception`, so `KeyboardInterrupt`/`SystemExit`/`GeneratorExit` aren't captured). Without this, change 1 alone would turn the symptom into "chains from `None`" on that path; together they mean the cause is always correct or absent, never wrong.

## Verification

- **Reproduced end-to-end against a live PostgreSQL** (real `BEGIN`/`SAVEPOINT`/`ROLLBACK`, real SQL errors): before the fix, transaction 2's `TransactionManagementError.__cause__` was transaction 1's `UndefinedTable`; after, it's transaction 2's own error.
- **New regression test** `tests/internal/test_rollback_exc_attribution.py`. Each of the two source changes is guarded by exactly one test method (verified by reverting each change independently — the matching test fails, the other passes). Uses `isolated_db` (not `db`) because the `db` fixture opens an ambient `atomic()` that would demote the in-test blocks to savepoints and stop the outermost-entry clearing from ever firing.
- Full `plain-postgres` suite green apart from pre-existing failures unrelated to this change (environment-specific: Unix-socket `server.address`, exclusion-constraint extensions, management-connection socket handling).

## Notes

- Two rare failure paths (a savepoint rollback/release that *itself* fails) still mark `needs_rollback` without recording a cause, so they chain from `None`. That's honest — not a cross-transaction leak, since change 1 clears the stale value on every outermost entry — and matches prior behavior. Deliberately left rather than scattering `rollback_exc = None` across every `needs_rollback` mutation site, which would spread the invariant thin without closing a real leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkCks98EGvmozGkfeqGXfR)_