### PR TITLE
Rename select_for_update() to for_update() and add lock-mode variants

### DIFF
--- a/plain-jobs/plain/jobs/workers.py
+++ b/plain-jobs/plain/jobs/workers.py
@@ -325,7 +325,7 @@ class Worker:
             job_request = (
                 JobRequest.query.ready_to_run()
                 .filter(queue__in=self.queues)
-                .select_for_update(skip_locked=True)
+                .for_update(skip_locked=True)
                 .order_by("-priority", "-start_at", "-created_at")
                 .first()
             )

--- a/plain-jobs/tests/internal/test_priority.py
+++ b/plain-jobs/tests/internal/test_priority.py
@@ -81,7 +81,7 @@ def test_worker_ordering_priority_then_created_at(db):
         created_at=now - datetime.timedelta(minutes=5),
     )
 
-    # Simulate the worker's query (without select_for_update for test simplicity)
+    # Simulate the worker's query (without for_update() for test simplicity)
     jobs = list(
         JobRequest.query.filter(queue__in=["default"])
         .ready_to_run()

--- a/plain-oauthserver/plain/oauthserver/views.py
+++ b/plain-oauthserver/plain/oauthserver/views.py
@@ -281,7 +281,7 @@ class TokenView(View):
         # Lock the code row so two concurrent exchanges can't both spend it.
         with transaction.atomic():
             try:
-                auth_code = AuthorizationCode.query.select_for_update().get(
+                auth_code = AuthorizationCode.query.for_update().get(
                     code=code_value, application=application
                 )
             except AuthorizationCode.DoesNotExist:
@@ -317,7 +317,7 @@ class TokenView(View):
         with transaction.atomic():
             try:
                 refresh = (
-                    RefreshToken.query.select_for_update()
+                    RefreshToken.query.for_update()
                     .select_related("access_token")
                     .get(token_hash=_hash_token(token_value), application=application)
                 )

--- a/plain-postgres/plain/postgres/README.md
+++ b/plain-postgres/plain/postgres/README.md
@@ -486,6 +486,39 @@ with read_only():
     User.query.count()   # still works — outer txn is healthy
 ```
 
+### Row-level locking
+
+Lock the rows a query selects so concurrent transactions can't change them until yours commits. Postgres offers four lock strengths, from strongest to weakest, each with its own QuerySet method:
+
+```python
+with transaction.atomic():
+    account = Account.query.for_update().get(id=1)  # FOR UPDATE
+    account.balance -= 100
+    account.update(fields=["balance"])
+```
+
+| Method                | SQL clause          | Use it when                                                                |
+| --------------------- | ------------------- | -------------------------------------------------------------------------- |
+| `for_update()`        | `FOR UPDATE`        | You intend to update or delete the row.                                    |
+| `for_no_key_update()` | `FOR NO KEY UPDATE` | Same, but you won't touch the primary key — lets key-share locks proceed.  |
+| `for_share()`         | `FOR SHARE`         | You need the row to stay put while you read it, but others may also share. |
+| `for_key_share()`     | `FOR KEY SHARE`     | Weakest — only blocks changes to the row's key.                            |
+
+Locking requires an open transaction; calling any of these outside `transaction.atomic()` raises `TransactionManagementError`.
+
+All four accept the same options:
+
+- `nowait=True` — raise instead of waiting if a row is already locked.
+- `skip_locked=True` — skip already-locked rows instead of waiting (can't be combined with `nowait`).
+- `of=("self", "related")` — lock only the named tables in a join rather than every selected row.
+
+```python
+# Claim the next available job without blocking on rows another worker holds
+job = Job.query.for_update(skip_locked=True).filter(status="pending").first()
+```
+
+Chaining more than one lock method keeps only the last one.
+
 ## Schema management
 
 Schema changes fall into three categories, each with a different author and apply model:

--- a/plain-postgres/plain/postgres/dialect.py
+++ b/plain-postgres/plain/postgres/dialect.py
@@ -312,15 +312,15 @@ def distinct_sql(
         return ["DISTINCT"], []
 
 
-def for_update_sql(
+def lock_sql(
+    mode: str,
     nowait: bool = False,
     skip_locked: bool = False,
     of: tuple[str, ...] = (),
-    no_key: bool = False,
 ) -> str:
-    """Return the FOR UPDATE SQL clause to lock rows for an update operation."""
-    return "FOR{} UPDATE{}{}{}".format(
-        " NO KEY" if no_key else "",
+    """Return a row-level locking clause (FOR UPDATE, FOR SHARE, etc.)."""
+    return "{}{}{}{}".format(
+        mode,
         " OF {}".format(", ".join(of)) if of else "",
         " NOWAIT" if nowait else "",
         " SKIP LOCKED" if skip_locked else "",

--- a/plain-postgres/plain/postgres/dialect.py
+++ b/plain-postgres/plain/postgres/dialect.py
@@ -24,6 +24,7 @@ from plain.utils.regex_helper import _lazy_re_compile
 
 if TYPE_CHECKING:
     from plain.postgres.fields import Field
+    from plain.postgres.sql.query import LockMode
 
 # Start and end points for window expressions.
 PRECEDING: str = "PRECEDING"
@@ -312,15 +313,23 @@ def distinct_sql(
         return ["DISTINCT"], []
 
 
+LOCK_MODE_SQL = {
+    "update": "FOR UPDATE",
+    "no_key_update": "FOR NO KEY UPDATE",
+    "share": "FOR SHARE",
+    "key_share": "FOR KEY SHARE",
+}
+
+
 def lock_sql(
-    mode: str,
+    mode: LockMode,
     nowait: bool = False,
     skip_locked: bool = False,
     of: tuple[str, ...] = (),
 ) -> str:
     """Return a row-level locking clause (FOR UPDATE, FOR SHARE, etc.)."""
     return "{}{}{}{}".format(
-        mode,
+        LOCK_MODE_SQL[mode],
         " OF {}".format(", ".join(of)) if of else "",
         " NOWAIT" if nowait else "",
         " SKIP LOCKED" if skip_locked else "",

--- a/plain-postgres/plain/postgres/query.py
+++ b/plain-postgres/plain/postgres/query.py
@@ -40,6 +40,7 @@ from plain.postgres.sql import (
     OR,
     DeleteQuery,
     InsertQuery,
+    LockMode,
     Query,
     RawQuery,
     UpdateQuery,
@@ -1164,7 +1165,7 @@ class QuerySet[T: "Model"]:
         of: tuple[str, ...] = (),
     ) -> QuerySet[T]:
         """Return a new QuerySet that locks selected rows with FOR UPDATE."""
-        return self._lock_rows("FOR UPDATE", nowait, skip_locked, of)
+        return self._lock_rows("update", nowait, skip_locked, of)
 
     def for_no_key_update(
         self,
@@ -1173,7 +1174,7 @@ class QuerySet[T: "Model"]:
         of: tuple[str, ...] = (),
     ) -> QuerySet[T]:
         """Return a new QuerySet that locks selected rows with FOR NO KEY UPDATE."""
-        return self._lock_rows("FOR NO KEY UPDATE", nowait, skip_locked, of)
+        return self._lock_rows("no_key_update", nowait, skip_locked, of)
 
     def for_share(
         self,
@@ -1182,7 +1183,7 @@ class QuerySet[T: "Model"]:
         of: tuple[str, ...] = (),
     ) -> QuerySet[T]:
         """Return a new QuerySet that locks selected rows with FOR SHARE."""
-        return self._lock_rows("FOR SHARE", nowait, skip_locked, of)
+        return self._lock_rows("share", nowait, skip_locked, of)
 
     def for_key_share(
         self,
@@ -1191,11 +1192,11 @@ class QuerySet[T: "Model"]:
         of: tuple[str, ...] = (),
     ) -> QuerySet[T]:
         """Return a new QuerySet that locks selected rows with FOR KEY SHARE."""
-        return self._lock_rows("FOR KEY SHARE", nowait, skip_locked, of)
+        return self._lock_rows("key_share", nowait, skip_locked, of)
 
     def _lock_rows(
         self,
-        mode: str,
+        mode: LockMode,
         nowait: bool,
         skip_locked: bool,
         of: tuple[str, ...],

--- a/plain-postgres/plain/postgres/query.py
+++ b/plain-postgres/plain/postgres/query.py
@@ -857,9 +857,7 @@ class QuerySet[T: "Model"]:
         with transaction.atomic():
             # Lock the row so that a concurrent update is blocked until
             # update_or_create() has performed its save.
-            obj, created = self.select_for_update().get_or_create(
-                create_defaults, **kwargs
-            )
+            obj, created = self.for_update().get_or_create(create_defaults, **kwargs)
             if created:
                 return obj, created
             for k, v in resolve_callables(update_defaults):
@@ -939,7 +937,7 @@ class QuerySet[T: "Model"]:
             raise TypeError("Cannot call delete() after .values() or .values_list()")
 
         del_query = self._chain()
-        del_query.sql_query.select_for_update = False
+        del_query.sql_query.lock_mode = None
         del_query.sql_query.select_related = False
         del_query.sql_query.clear_ordering(force=True)
 
@@ -1159,25 +1157,60 @@ class QuerySet[T: "Model"]:
         else:
             self._query.add_q(Q(*args, **kwargs))
 
-    def select_for_update(
+    def for_update(
         self,
         nowait: bool = False,
         skip_locked: bool = False,
         of: tuple[str, ...] = (),
-        no_key: bool = False,
+    ) -> QuerySet[T]:
+        """Return a new QuerySet that locks selected rows with FOR UPDATE."""
+        return self._lock_rows("FOR UPDATE", nowait, skip_locked, of)
+
+    def for_no_key_update(
+        self,
+        nowait: bool = False,
+        skip_locked: bool = False,
+        of: tuple[str, ...] = (),
+    ) -> QuerySet[T]:
+        """Return a new QuerySet that locks selected rows with FOR NO KEY UPDATE."""
+        return self._lock_rows("FOR NO KEY UPDATE", nowait, skip_locked, of)
+
+    def for_share(
+        self,
+        nowait: bool = False,
+        skip_locked: bool = False,
+        of: tuple[str, ...] = (),
+    ) -> QuerySet[T]:
+        """Return a new QuerySet that locks selected rows with FOR SHARE."""
+        return self._lock_rows("FOR SHARE", nowait, skip_locked, of)
+
+    def for_key_share(
+        self,
+        nowait: bool = False,
+        skip_locked: bool = False,
+        of: tuple[str, ...] = (),
+    ) -> QuerySet[T]:
+        """Return a new QuerySet that locks selected rows with FOR KEY SHARE."""
+        return self._lock_rows("FOR KEY SHARE", nowait, skip_locked, of)
+
+    def _lock_rows(
+        self,
+        mode: str,
+        nowait: bool,
+        skip_locked: bool,
+        of: tuple[str, ...],
     ) -> QuerySet[T]:
         """
-        Return a new QuerySet instance that will select objects with a
-        FOR UPDATE lock.
+        Build a new QuerySet carrying a row-level locking clause. Calling more
+        than one lock method on a chain keeps only the last mode.
         """
         if nowait and skip_locked:
             raise ValueError("The nowait option cannot be used with skip_locked.")
         obj = self._chain()
-        obj.sql_query.select_for_update = True
-        obj.sql_query.select_for_update_nowait = nowait
-        obj.sql_query.select_for_update_skip_locked = skip_locked
-        obj.sql_query.select_for_update_of = of
-        obj.sql_query.select_for_no_key_update = no_key
+        obj.sql_query.lock_mode = mode
+        obj.sql_query.lock_nowait = nowait
+        obj.sql_query.lock_skip_locked = skip_locked
+        obj.sql_query.lock_of = of
         return obj
 
     def select_related(self, *fields: str | None) -> Self:

--- a/plain-postgres/plain/postgres/sql/__init__.py
+++ b/plain-postgres/plain/postgres/sql/__init__.py
@@ -12,6 +12,7 @@ from plain.postgres.sql.query import (
     AggregateQuery,
     DeleteQuery,
     InsertQuery,
+    LockMode,
     Query,
     RawQuery,
     UpdateQuery,
@@ -25,6 +26,7 @@ __all__ = [
     "DeleteQuery",
     "InsertQuery",
     "UpdateQuery",
+    "LockMode",
     "AND",
     "OR",
     # Constants

--- a/plain-postgres/plain/postgres/sql/compiler.py
+++ b/plain-postgres/plain/postgres/sql/compiler.py
@@ -14,8 +14,8 @@ from plain.postgres.dialect import (
     bulk_insert_sql,
     distinct_sql,
     explain_query_prefix,
-    for_update_sql,
     limit_offset_sql,
+    lock_sql,
     on_conflict_suffix_sql,
     quote_name,
     return_insert_columns,
@@ -622,7 +622,7 @@ class SQLCompiler:
             assert result is not None  # SQLCompiler.pre_sql_setup always returns tuple
             extra_select, order_by, group_by = result
             assert self.select is not None  # Set by pre_sql_setup()
-            for_update_part = None
+            lock_part = None
             # Is a LIMIT/OFFSET clause needed?
             with_limit_offset = with_limits and self.query.is_sliced
             if self.qualify:
@@ -675,17 +675,17 @@ class SQLCompiler:
                     result += ["FROM", *from_]
                 params.extend(f_params)
 
-                if self.query.select_for_update:
+                if self.query.lock_mode:
                     if self.connection.get_autocommit():
                         raise TransactionManagementError(
-                            "select_for_update cannot be used outside of a transaction."
+                            "for_update cannot be used outside of a transaction."
                         )
 
-                    for_update_part = for_update_sql(
-                        nowait=self.query.select_for_update_nowait,
-                        skip_locked=self.query.select_for_update_skip_locked,
-                        of=tuple(self.get_select_for_update_of_arguments()),
-                        no_key=self.query.select_for_no_key_update,
+                    lock_part = lock_sql(
+                        mode=self.query.lock_mode,
+                        nowait=self.query.lock_nowait,
+                        skip_locked=self.query.lock_skip_locked,
+                        of=tuple(self.get_lock_of_arguments()),
                     )
 
                 if where:
@@ -730,8 +730,8 @@ class SQLCompiler:
                     limit_offset_sql(self.query.low_mark, self.query.high_mark)
                 )
 
-            if for_update_part:
-                result.append(for_update_part)
+            if lock_part:
+                result.append(lock_part)
 
             if self.query.subquery and extra_select:
                 # If the query is used as a subquery, the extra selects would
@@ -1122,10 +1122,10 @@ class SQLCompiler:
                 )
         return related_klass_infos
 
-    def get_select_for_update_of_arguments(self) -> list[str]:
+    def get_lock_of_arguments(self) -> list[str]:
         """
-        Return a quoted list of arguments for the SELECT FOR UPDATE OF part of
-        the query.
+        Return a quoted list of arguments for the OF part of a row-level
+        locking clause (FOR UPDATE OF ..., FOR SHARE OF ..., etc.).
         """
 
         def _get_first_selected_col_from_model(klass_info: dict) -> Any | None:
@@ -1169,7 +1169,7 @@ class SQLCompiler:
             return []
         result = []
         invalid_names = []
-        for name in self.query.select_for_update_of:
+        for name in self.query.lock_of:
             klass_info = self.klass_info
             if name == "self":
                 col = _get_first_selected_col_from_model(klass_info)
@@ -1196,7 +1196,7 @@ class SQLCompiler:
                 result.append(self.quote_name_unless_alias(col.alias))
         if invalid_names:
             raise FieldError(
-                "Invalid field name(s) given in select_for_update(of=(...)): {}. "
+                "Invalid field name(s) given in the of=(...) argument: {}. "
                 "Only relational fields followed in the query are allowed. "
                 "Choices are: {}.".format(
                     ", ".join(invalid_names),

--- a/plain-postgres/plain/postgres/sql/query.py
+++ b/plain-postgres/plain/postgres/sql/query.py
@@ -188,6 +188,10 @@ class TransformWrapper:
 
 QueryType = TypeVar("QueryType", bound="Query")
 
+# Row-level locking mode requested via QuerySet.for_update() and friends.
+# dialect.lock_sql() maps each token to its actual SQL keywords.
+LockMode = Literal["update", "no_key_update", "share", "key_share"]
+
 
 class Query(BaseExpression):
     """A single SQL query."""
@@ -226,7 +230,7 @@ class Query(BaseExpression):
     high_mark = None  # Used for offset/limit.
     distinct = False
     distinct_fields: tuple[str, ...] = ()
-    lock_mode: str | None = None  # The row-level locking clause, e.g. "FOR UPDATE".
+    lock_mode: LockMode | None = None  # See LockMode.
     lock_nowait = False
     lock_skip_locked = False
     lock_of: tuple[str, ...] = ()

--- a/plain-postgres/plain/postgres/sql/query.py
+++ b/plain-postgres/plain/postgres/sql/query.py
@@ -226,11 +226,10 @@ class Query(BaseExpression):
     high_mark = None  # Used for offset/limit.
     distinct = False
     distinct_fields: tuple[str, ...] = ()
-    select_for_update = False
-    select_for_update_nowait = False
-    select_for_update_skip_locked = False
-    select_for_update_of: tuple[str, ...] = ()
-    select_for_no_key_update = False
+    lock_mode: str | None = None  # The row-level locking clause, e.g. "FOR UPDATE".
+    lock_nowait = False
+    lock_skip_locked = False
+    lock_of: tuple[str, ...] = ()
     select_related: bool | dict[str, Any] = False
     has_select_fields = False
     # Arbitrary limit for select_related to prevents infinite recursion.
@@ -428,7 +427,7 @@ class Query(BaseExpression):
             inner_query = self.clone()
             inner_query.subquery = True
             outer_query = AggregateQuery(self.model, inner_query)
-            inner_query.select_for_update = False
+            inner_query.lock_mode = None
             inner_query.select_related = False
             inner_query.set_annotation_mask(self.annotation_select)
             # Queries with distinct_fields need ordering and when a limit is
@@ -520,7 +519,7 @@ class Query(BaseExpression):
         elide_empty = not any(result is NotImplemented for result in empty_set_result)
         outer_query.clear_ordering(force=True)
         outer_query.clear_limits()
-        outer_query.select_for_update = False
+        outer_query.lock_mode = None
         outer_query.select_related = False
         compiler = outer_query.get_compiler(elide_empty=elide_empty)
         result = compiler.execute_sql(SINGLE)
@@ -2077,9 +2076,7 @@ class Query(BaseExpression):
         If 'clear_default' is True, there will be no ordering in the resulting
         query (not even the model's default).
         """
-        if not force and (
-            self.is_sliced or self.distinct_fields or self.select_for_update
-        ):
+        if not force and (self.is_sliced or self.distinct_fields or self.lock_mode):
             return
         self.order_by = ()
         if clear_default:

--- a/plain-postgres/tests/public/test_row_locking.py
+++ b/plain-postgres/tests/public/test_row_locking.py
@@ -1,0 +1,74 @@
+"""
+Row-level locking: for_update(), for_no_key_update(), for_share(), and
+for_key_share() emit the matching Postgres locking clause and options.
+"""
+
+from __future__ import annotations
+
+import pytest
+from app.examples.models.relationships import Widget
+
+from plain.postgres import transaction
+from plain.postgres.transaction import TransactionManagementError
+
+
+def _executed_sql(queries: list[dict]) -> str:
+    return " ".join(q["sql"] for q in queries)
+
+
+@pytest.mark.parametrize(
+    ("method", "clause"),
+    [
+        ("for_update", "FOR UPDATE"),
+        ("for_no_key_update", "FOR NO KEY UPDATE"),
+        ("for_share", "FOR SHARE"),
+        ("for_key_share", "FOR KEY SHARE"),
+    ],
+)
+def test_lock_method_emits_its_clause(db, capture_queries, method, clause):
+    with capture_queries() as queries:
+        list(getattr(Widget.query, method)())
+    assert clause in _executed_sql(queries)
+
+
+def test_nowait_appends_nowait(db, capture_queries):
+    with capture_queries() as queries:
+        list(Widget.query.for_update(nowait=True))
+    assert "FOR UPDATE NOWAIT" in _executed_sql(queries)
+
+
+def test_skip_locked_appends_skip_locked(db, capture_queries):
+    with capture_queries() as queries:
+        list(Widget.query.for_share(skip_locked=True))
+    assert "FOR SHARE SKIP LOCKED" in _executed_sql(queries)
+
+
+def test_of_restricts_lock_to_named_table(db, capture_queries):
+    with capture_queries() as queries:
+        list(Widget.query.for_update(of=("self",)))
+    assert "FOR UPDATE OF" in _executed_sql(queries)
+
+
+def test_nowait_and_skip_locked_together_raise():
+    with pytest.raises(ValueError, match="nowait"):
+        Widget.query.for_update(nowait=True, skip_locked=True)
+
+
+def test_last_lock_mode_wins(db, capture_queries):
+    with capture_queries() as queries:
+        list(Widget.query.for_update().for_share())
+    sql = _executed_sql(queries)
+    assert "FOR SHARE" in sql
+    assert "FOR UPDATE" not in sql
+
+
+def test_lock_requires_a_transaction(isolated_db):
+    with pytest.raises(TransactionManagementError):
+        list(Widget.query.for_update())
+
+
+def test_lock_works_inside_atomic(isolated_db):
+    Widget.query.create(name="W", size="L")
+    with transaction.atomic():
+        widgets = list(Widget.query.for_update())
+    assert len(widgets) == 1


### PR DESCRIPTION
Postgres exposes four row-level lock strengths, but the ORM only offered `FOR UPDATE` (via `select_for_update()`, with a `no_key=` kwarg for the NO KEY variant). This adds all four as explicit QuerySet methods and drops the old name.

## API

```python
Model.query.for_update()         # FOR UPDATE
Model.query.for_no_key_update()  # FOR NO KEY UPDATE
Model.query.for_share()          # FOR SHARE
Model.query.for_key_share()      # FOR KEY SHARE
```

All four take the same `nowait=`, `skip_locked=`, and `of=` options. The old `select_for_update()` method and its `no_key=` kwarg are removed (no alias/shim — renames are handled by the upgrade agent). `nowait` + `skip_locked` together still raises `ValueError`; evaluating a locked queryset outside a transaction still raises `TransactionManagementError`, and that message now names the clause the query actually asked for instead of always saying `for_update`. Chaining two lock methods keeps the last one, options included.

**Upgrade step:** `select_for_update()` → `for_update()`, and `select_for_update(no_key=True)` → `for_no_key_update()`. Everything else about the call is unchanged.

## Internals

The five booleans on `Query` (`select_for_update`, `select_for_update_nowait`, `select_for_update_skip_locked`, `select_for_update_of`, `select_for_no_key_update`) collapse into a single `lock_mode: LockMode | None` (a `Literal["update", "no_key_update", "share", "key_share"]`) plus `lock_nowait`, `lock_skip_locked`, `lock_of`. The compiler passes `lock_mode` straight through to `dialect.lock_sql(mode, ...)`, which maps the token to its actual SQL keywords via `LOCK_MODE_SQL` — the queryset itself never carries raw SQL, only the mode token.

`LOCK_MODE_SQL` is typed `dict[LockMode, str]`, so an invalid key is a type error; an internal test asserts the mapping is exhaustive over the `Literal`, which the annotation alone doesn't cover.

## Callers updated

Each keeps the lock strength it had:

- `plain-jobs` worker claim query (`.for_update(skip_locked=True)`)
- `plain-oauthserver` token exchange / refresh (`.for_update()`)
- internal `update_or_create` and `delete` paths

## Unlockable query shapes fail at construction

Postgres can only lock rows that map one-to-one onto table rows, so it refuses a locking clause alongside `DISTINCT`, `GROUP BY`, an aggregate, or a window function — but only says so at execution time, a long way from where the queryset was built. Both orders now raise `psycopg.NotSupportedError` up front:

```python
Widget.query.distinct().for_update()                  # NotSupportedError: for_update() cannot be combined with distinct()
Widget.query.for_update().distinct()                  # same error, either way round
Widget.query.annotate(n=Count("id")).for_share()      # ... with an aggregate annotation
Widget.query.for_update().annotate(rn=Window(...))    # ... with a window annotation
```

The lock method's name is derived from the mode token (`for_{mode}()`), so there's no second mode→name table to keep in sync with `LockMode`. A non-aggregate annotation is still fine — only aggregation forces a `GROUP BY`.

Set operations aren't in the list because this ORM has no `union()`/`intersection()`/`difference()`.

## Not changed

`count()`/`aggregate()` still drop the lock (they compile to an aggregate query of their own) while `exists()` keeps it. Both predate this PR; the README documents them and a test pins them.

## Tests

`plain-postgres/tests/public/test_row_locking.py`: each mode emits its clause, `nowait`/`skip_locked`/`of` render, `nowait`+`skip_locked` raises, last-mode-wins, lock-requires-transaction (asserting the message names the mode), a behavioral check that a lock works inside `atomic()`, both orders of every lock × `distinct()` combination, aggregate and window annotations from both directions, and that `count()`/`aggregate()` still drop the lock. `tests/internal/test_lock_mode_sql.py` pins the mode→SQL mapping to the `Literal`.

## Docs

New "Row-level locking" section in the plain-postgres README under Transactions.
