### PR TITLE
Use tuples for tools/resources in plain.mcp docs

### DIFF
--- a/plain-mcp/plain/mcp/README.md
+++ b/plain-mcp/plain/mcp/README.md
@@ -44,7 +44,7 @@ class Greet(MCPTool):
 class AppMCP(MCPView, AuthView):
     name = "myapp"
     login_required = True
-    tools = [Greet]
+    tools = (Greet,)
 ```
 
 Mount it:
@@ -186,12 +186,12 @@ class ListMyNotes(AppTool):
 
 class AppMCP(OAuthResourceServer, MCPView):
     name = "myapp"
-    tools = [ListMyNotes]
+    tools = (ListMyNotes,)
 
     def authenticate_token(self, token: str) -> TokenInfo | None: ...
 ```
 
-The `mcp: AppMCP` annotation is a forward reference (resolved lazily), so this natural order just works — base tool and tools first, then the view with `tools = [...]`. A tool that needs nothing view-specific stays bare — `class Greet(MCPTool)` — and `self.mcp` is the base `MCPView` (request, no user).
+The `mcp: AppMCP` annotation is a forward reference (resolved lazily), so this natural order just works — base tool and tools first, then the view with `tools = (...)`. A tool that needs nothing view-specific stays bare — `class Greet(MCPTool)` — and `self.mcp` is the base `MCPView` (request, no user).
 
 **Signaling errors.** Raise [`MCPToolError`](./exceptions.py#MCPToolError) from `run()` for an expected, caller-facing failure — bad input, not found, forbidden. The message goes back to the client with `isError: true` (MCP's in-result error channel) so the model can self-correct, and it is _not_ logged as a server exception. Any other exception is treated as a bug: logged server-side and returned as an opaque "Tool execution failed".
 
@@ -284,7 +284,7 @@ class ListOrders(ReadTool):
 
 ## Resources
 
-Resources are addressable data sources your server exposes for reading. Each resource is an [`MCPResource`](./resources.py#MCPResource) subclass with a URI and a `read()` method. Declare them on the MCP with `resources = [...]` (parallel to `tools`):
+Resources are addressable data sources your server exposes for reading. Each resource is an [`MCPResource`](./resources.py#MCPResource) subclass with a URI and a `read()` method. Declare them on the MCP with `resources = (...)` (parallel to `tools`):
 
 ```python
 from pathlib import Path
@@ -315,7 +315,7 @@ class AppReadme(MCPResource):
 
 class AppMCP(MCPView):
     name = "myapp"
-    resources = [AppVersion, AppReadme]
+    resources = (AppVersion, AppReadme)
 ```
 
 Metadata is derived automatically:
@@ -370,13 +370,13 @@ from plain.mcp import MCPUnauthorized, MCPView
 class AppMCP(MCPView, AuthView):
     name = "myapp-api"
     login_required = True
-    tools = [ListCustomerOrders]
+    tools = (ListCustomerOrders,)
 
 
 class StaffMCP(MCPView, AuthView):
     name = "myapp-staff"
     login_required = True
-    tools = [DescribeSchema]
+    tools = (DescribeSchema,)
 
     def check_auth(self):
         super().check_auth()  # login_required from AuthView
@@ -498,7 +498,7 @@ from plain.oauthserver import validate_access_token
 
 class AppMCP(OAuthResourceServer, MCPView):
     name = "myapp"
-    tools = [...]
+    tools = (MyTool,)
 
     def authenticate_token(self, token: str) -> TokenInfo | None:
         at = validate_access_token(token, resource=self.oauth_resource)
@@ -590,7 +590,7 @@ class AppMCP(MCPView, AuthView):
 
     def get_tools(self):
         if self.user and self.user.is_superuser:
-            return self.tools  # superuser sees everything, skipping allowed_for
+            return list(self.tools)  # superuser sees everything, skipping allowed_for
         tools = super().get_tools()  # applies each tool's allowed_for
         if settings.READONLY_MODE:
             tools = [t for t in tools if not getattr(t, "mutates", False)]

--- a/plain-mcp/plain/mcp/oauth.py
+++ b/plain-mcp/plain/mcp/oauth.py
@@ -60,7 +60,7 @@ class OAuthResourceServer:
 
         class AppMCP(OAuthResourceServer, MCPView):
             name = "myapp"
-            tools = [...]
+            tools = (MyTool,)
 
             def authenticate_token(self, token):
                 at = validate_access_token(token, resource=self.oauth_resource)

--- a/plain-mcp/plain/mcp/views.py
+++ b/plain-mcp/plain/mcp/views.py
@@ -107,7 +107,7 @@ class MCPView(View):
 
         class AppMCP(MCPView):
             name = "myapp"
-            tools = [Greet]
+            tools = (Greet,)
 
         # app/urls.py
         path("mcp", AppMCP, name="mcp")
@@ -122,7 +122,7 @@ class MCPView(View):
 
         class AppMCP(MCPView):
             name = "myapp"
-            tools = [Greet, Search]
+            tools = (Greet, Search)
 
     Or imperatively, which is how third-party packages attach to a shared
     MCPView they don't own (e.g. `plain.admin.mcp.AdminMCP`):


### PR DESCRIPTION
`MCPView.tools` and `MCPView.resources` are annotated `tuple[type[MCPTool], ...]` / `tuple[type[MCPResource], ...]`, and the framework convention is that declarative class attributes are tuples. The plain-mcp README examples and the `MCPView` / `OAuthResourceServer` docstrings still assigned lists.

Docs only — no runtime behavior changes.

## Changes

- `plain-mcp/plain/mcp/README.md` — every `tools = [...]` / `resources = [...]` example (and the two prose mentions) now uses tuple syntax, e.g. `tools = (Greet,)`, `resources = (AppVersion, AppReadme)`.
- The two `tools = [...]` ellipsis placeholders in the OAuth section become a real one-element tuple `tools = (MyTool,)`, so the snippet is valid as written.
- The `get_tools()` override example returns `list(self.tools)` instead of `self.tools`, matching the documented `list[type[MCPTool]]` return type of `get_tools()`.
- `plain-mcp/plain/mcp/views.py`, `plain-mcp/plain/mcp/oauth.py` — same fix in the class docstrings.

## Notes on the type-checking claim

The list form is a real type error under pyright (`reportAssignmentType`), which is what surfaced this. Worth noting for accuracy: `ty` — the checker `./scripts/type-check` and `plain check` use — does **not** currently flag it. I verified this: even `tools = 5` on an `MCPView` subclass passes `ty` today, so it doesn't validate assignments that override an inherited annotated attribute. So the shipped examples were not failing `plain check`; they were inconsistent with the documented convention and would fail for users on pyright/mypy.

## Testing

- `./scripts/fix` — ruff check and ruff format pass. Its oxlint step could not run in this environment (TLS failure downloading the binary); no JS/CSS was touched.
- `./scripts/test plain-mcp` could not run here — no Postgres available in the sandbox. The change is markdown and docstrings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwkxmxUXppGucqgS7HGZnM


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwkxmxUXppGucqgS7HGZnM)_