### PR TITLE
Type Meta.fields and local_fields as ColumnField

### DIFF
--- a/plain-postgres/plain/postgres/base.py
+++ b/plain-postgres/plain/postgres/base.py
@@ -27,7 +27,6 @@ from plain.postgres.exceptions import (
 )
 from plain.postgres.expressions import RawSQL, Value
 from plain.postgres.fields import DATABASE_DEFAULT, Field
-from plain.postgres.fields.base import ColumnField
 from plain.postgres.fields.related import RelatedField
 from plain.postgres.fields.reverse_related import ForeignObjectRel
 from plain.postgres.meta import Meta
@@ -122,10 +121,6 @@ class Model(metaclass=ModelBase):
         # Process all fields from kwargs or use defaults
         for field in meta.fields:
             from plain.postgres.fields.related import RelatedField
-
-            # meta.fields excludes ManyToManyField, so every iterated field
-            # is column-backed and exposes the ColumnField surface.
-            assert isinstance(field, ColumnField)
 
             is_related_object = False
             # Virtual field
@@ -705,8 +700,6 @@ class Model(metaclass=ModelBase):
 
         errors = {}
         for f in self._model_meta.fields:
-            # See __init__ above: meta.fields is always ColumnField.
-            assert isinstance(f, ColumnField)
             if f.name in exclude:
                 continue
             # Skip validation for empty fields with required=False. The developer

--- a/plain-postgres/plain/postgres/convergence/analysis.py
+++ b/plain-postgres/plain/postgres/convergence/analysis.py
@@ -21,7 +21,6 @@ from ..ddl import (
     compile_literal_default_sql,
 )
 from ..dialect import quote_name
-from ..fields.base import ColumnField
 from ..fields.related import ForeignKeyField
 from ..indexes import Index
 from ..introspection import (
@@ -587,8 +586,6 @@ def _compare_columns(
     expected_col_names: set[str] = set()
 
     for f in model._model_meta.local_fields:
-        if not isinstance(f, ColumnField):
-            continue
         db_type = f.db_type()
         if db_type is None:
             continue

--- a/plain-postgres/plain/postgres/meta.py
+++ b/plain-postgres/plain/postgres/meta.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from plain.postgres.base import Model
     from plain.postgres.constraints import BaseConstraint
     from plain.postgres.fields import Field
+    from plain.postgres.fields.base import ColumnField
     from plain.postgres.fields.related import (
         ForeignKeyField,
         ManyToManyField,
@@ -61,7 +62,7 @@ class Meta:
     model: type[Model]
     models_registry: Any
     _get_fields_cache: dict[Any, Any]
-    local_fields: list[Field]
+    local_fields: list[ColumnField]
     local_many_to_many: list[ManyToManyField]
 
     def __init__(self, models_registry: Any | None = None):
@@ -156,12 +157,18 @@ class Meta:
         return QuerySet.from_model(self.model)
 
     def add_field(self, field: Field) -> None:
+        from plain.postgres.fields.base import ColumnField
         from plain.postgres.fields.related import ManyToManyField, RelatedField
 
+        # Every field is either column-backed or a many-to-many; keeping the
+        # two lists homogeneous is what lets the rest of the framework read
+        # column attributes off `fields` without re-checking each one.
         if isinstance(field, ManyToManyField):
             self.local_many_to_many.append(field)
-        else:
+        elif isinstance(field, ColumnField):
             self.local_fields.append(field)
+        else:
+            raise TypeError(f"{field!r} is neither a ColumnField nor a ManyToManyField")
 
         # If the field being added is a relation to another known field,
         # expire the cache on this field and the forward cache on the field
@@ -181,45 +188,19 @@ class Meta:
             self._expire_cache(reverse=False)
 
     @cached_property
-    def fields(self) -> ImmutableList[Field]:
-        from plain.postgres.fields.related import RelatedField
-
+    def fields(self) -> ImmutableList[ColumnField]:
         """
-        Return a list of all forward fields on the model and its parents,
+        Return a list of all column-backed forward fields on the model,
         excluding ManyToManyFields.
 
         Private API intended only to be used by Plain itself; get_fields()
         combined with filtering of field properties is the public API for
         obtaining this field list.
         """
-
-        # For legacy reasons, the fields property should only contain forward
-        # fields that are not private or with a m2m cardinality.
-        def is_not_an_m2m_field(f: Any) -> bool:
-            from plain.postgres.fields.related import ManyToManyField
-
-            return not isinstance(f, ManyToManyField)
-
-        def is_not_a_generic_relation(f: Any) -> bool:
-            from plain.postgres.fields.related import ForeignKeyField, ManyToManyField
-
-            # Only ForeignKeyField and ManyToManyField are valid RelatedFields
-            # Anything else is a generic relation
-            if not isinstance(f, RelatedField):
-                return True
-            return isinstance(f, ForeignKeyField | ManyToManyField)
-
-        return make_immutable_fields_list(
-            "fields",
-            (
-                f
-                for f in self._get_fields(reverse=False)
-                if is_not_an_m2m_field(f) and is_not_a_generic_relation(f)
-            ),
-        )
+        return make_immutable_fields_list("fields", self.local_fields)
 
     @cached_property
-    def concrete_fields(self) -> ImmutableList[Field]:
+    def concrete_fields(self) -> ImmutableList[ColumnField]:
         """
         Return a list of all concrete fields on the model and its parents.
 
@@ -232,7 +213,7 @@ class Meta:
         )
 
     @cached_property
-    def local_concrete_fields(self) -> ImmutableList[Field]:
+    def local_concrete_fields(self) -> ImmutableList[ColumnField]:
         """
         Return a list of all concrete fields on the model.
 
@@ -505,7 +486,7 @@ class Meta:
         except KeyError:
             pass
 
-        fields = []
+        collected: list[Field | ForeignObjectRel] = []
 
         if reverse:
             # Tree is computed once and cached until the app cache is expired.
@@ -513,16 +494,15 @@ class Meta:
             # the current model (reverse relations).
             all_fields = self._relation_tree
             for field in all_fields:
-                fields.append(field.remote_field)
+                collected.append(field.remote_field)
 
         if forward:
-            # get_fields() intentionally returns a heterogeneous list of field types.
-            fields += self.local_fields  # ty: ignore[unsupported-operator]
-            fields += self.local_many_to_many  # ty: ignore[unsupported-operator]
+            collected += self.local_fields
+            collected += self.local_many_to_many
 
         # In order to avoid list manipulation. Always
         # return a shallow copy of the results
-        fields = make_immutable_fields_list("get_fields()", fields)
+        fields = make_immutable_fields_list("get_fields()", collected)
 
         # Store result into cache for later access
         self._get_fields_cache[cache_key] = fields

--- a/plain-postgres/plain/postgres/query.py
+++ b/plain-postgres/plain/postgres/query.py
@@ -998,7 +998,7 @@ class QuerySet[T: "Model"]:
         self._result_cache = None
         return rows
 
-    def _update(self, values: list[tuple[Field, Any]]) -> int:
+    def _update(self, values: Sequence[tuple[Field, Any]]) -> int:
         """
         A version of update() that accepts field objects instead of field names.
         Used primarily for model saving and not intended for use by general

--- a/plain-postgres/plain/postgres/sql/query.py
+++ b/plain-postgres/plain/postgres/sql/query.py
@@ -2564,7 +2564,7 @@ class UpdateQuery(Query):
             values_seq.append((field, val))
         return self.add_update_fields(values_seq)
 
-    def add_update_fields(self, values_seq: list[tuple[Any, Any]]) -> None:
+    def add_update_fields(self, values_seq: Sequence[tuple[Any, Any]]) -> None:
         """
         Append a sequence of (field, value) pairs to the internal list that
         will be used to generate the UPDATE query.


### PR DESCRIPTION
Follow-up to #103.

`Meta.fields`, `concrete_fields`, and `local_concrete_fields` were typed `ImmutableList[Field]` even though the only `Field` subclasses that aren't `ColumnField` are the abstract `RelatedField` and `ManyToManyField`, and M2M fields are routed to `local_many_to_many` in `add_field`. So every element really is a `ColumnField`, and #103 had to add an `assert isinstance(f, ColumnField)` inside `clean_fields` to read column attributes off it, next to a pre-existing one in `Model.__init__`.

- Type `local_fields`, `fields`, `concrete_fields`, and `local_concrete_fields` as `ColumnField`.
- Enforce the split once in `add_field` (raise `TypeError` for anything that is neither) instead of re-checking in every loop.
- `fields` is now just an immutable copy of `local_fields`; the "generic relation" filter it carried from Django was dead code since no such field class exists here.
- Drop the two `isinstance(…, ColumnField)` asserts in `base.py` and the equivalent skip in the convergence column comparison.
- Widen `QuerySet._update` and `UpdateQuery.add_update_fields` to `Sequence` so a `list[tuple[ColumnField, Any]]` passes without an invariance error.

Type ignores 148 → 146, asserts 176 → 173.

## Test plan

- [x] `./scripts/type-validate` 26/26
- [x] `./scripts/test plain-postgres`