### PR TITLE
Split unresolved model references from resolved rel.model and rel.through

### DIFF
--- a/plain-postgres/plain/postgres/base.py
+++ b/plain-postgres/plain/postgres/base.py
@@ -755,11 +755,14 @@ class Model(metaclass=ModelBase):
 
         fields = cls._model_meta.many_to_many
 
-        # Skip when the target model wasn't found.
-        fields = (f for f in fields if isinstance(f.remote_field.model, ModelBase))
-
-        # Skip when the relationship model wasn't found.
-        fields = (f for f in fields if isinstance(f.remote_field.through, ModelBase))
+        # Skip when the target or relationship model wasn't found; the field's
+        # own preflight reports those.
+        fields = (
+            f
+            for f in fields
+            if not isinstance(f.remote_field.model_ref, str)
+            and not isinstance(f.remote_field.through_ref, str)
+        )
 
         for f in fields:
             signature = (

--- a/plain-postgres/plain/postgres/base.py
+++ b/plain-postgres/plain/postgres/base.py
@@ -1111,11 +1111,11 @@ class Model(metaclass=ModelBase):
 
         for f in cls._model_meta.many_to_many:
             # Skip nonexistent models.
-            if isinstance(f.remote_field.through, str):
+            if isinstance(f.remote_field.through_ref, str):
                 continue
 
             # Check if column name for the M2M field is too long for the database.
-            for m2m in f.remote_field.through._model_meta.fields:
+            for m2m in f.remote_field.through_ref._model_meta.fields:
                 rel_name = m2m.column
                 if rel_name is not None and len(rel_name) > allowed_len:
                     errors.append(

--- a/plain-postgres/plain/postgres/fields/related.py
+++ b/plain-postgres/plain/postgres/fields/related.py
@@ -166,13 +166,13 @@ class RelatedField(FieldCacheMixin, Field):
 
     def _check_relation_model_exists(self) -> list[PreflightResult]:
         rel_is_missing = (
-            self.remote_field.model not in self.meta.models_registry.get_models()
+            self.remote_field.model_ref not in self.meta.models_registry.get_models()
         )
-        rel_is_string = isinstance(self.remote_field.model, str)
+        rel_is_string = isinstance(self.remote_field.model_ref, str)
         model_name = (
-            self.remote_field.model
+            self.remote_field.model_ref
             if rel_is_string
-            else self.remote_field.model.model_options.object_name
+            else self.remote_field.model_ref.model_options.object_name
         )
         if rel_is_missing and rel_is_string:
             return [
@@ -259,13 +259,13 @@ class RelatedField(FieldCacheMixin, Field):
         def resolve_related_class(
             model: type[Model], related: type[Model], field: RelatedField
         ) -> None:
-            field.remote_field.model = related
+            field.remote_field.model_ref = related
             field.do_related_class(related, model)
 
         lazy_related_operation(
             resolve_related_class,
             cls,
-            self.remote_field.model,
+            self.remote_field.model_ref,
             field=self,
         )
 
@@ -456,14 +456,14 @@ class ForeignKeyField(ColumnField, RelatedField):
         name, path, args, kwargs = super().deconstruct()
         kwargs["on_delete"] = self.remote_field.on_delete
 
-        if isinstance(self.remote_field.model, str):
-            if "." in self.remote_field.model:
-                package_label, model_name = self.remote_field.model.split(".")
+        if isinstance(self.remote_field.model_ref, str):
+            if "." in self.remote_field.model_ref:
+                package_label, model_name = self.remote_field.model_ref.split(".")
                 kwargs["to"] = f"{package_label}.{model_name.lower()}"
             else:
-                kwargs["to"] = self.remote_field.model.lower()
+                kwargs["to"] = self.remote_field.model_ref.lower()
         else:
-            kwargs["to"] = self.remote_field.model.model_options.label_lower
+            kwargs["to"] = self.remote_field.model_ref.model_options.label_lower
 
         return name, path, args, kwargs
 
@@ -473,10 +473,6 @@ class ForeignKeyField(ColumnField, RelatedField):
     @cached_property
     def target_field(self) -> Field:
         """A foreign key points at exactly one column: the remote model's id."""
-        if isinstance(self.remote_field.model, str):
-            raise TypeError(
-                f"Related model {self.remote_field.model!r} cannot be resolved"
-            )
         return self.remote_field.model._model_meta.get_forward_field("id")
 
     def set_attributes_from_name(self, name: str) -> None:
@@ -851,7 +847,7 @@ class ManyToManyField(RelatedField):
         return errors
 
     def _check_table_uniqueness(self, **kwargs: Any) -> list[PreflightResult]:
-        if isinstance(self.remote_field.through, str):
+        if isinstance(self.remote_field.through_ref, str):
             return []
         registered_tables = {
             model.model_options.db_table: model
@@ -880,19 +876,19 @@ class ManyToManyField(RelatedField):
         name, path, args, kwargs = super().deconstruct()
 
         # Lowercase model names as they should be treated as case-insensitive.
-        if isinstance(self.remote_field.model, str):
-            if "." in self.remote_field.model:
-                package_label, model_name = self.remote_field.model.split(".")
+        if isinstance(self.remote_field.model_ref, str):
+            if "." in self.remote_field.model_ref:
+                package_label, model_name = self.remote_field.model_ref.split(".")
                 kwargs["to"] = f"{package_label}.{model_name.lower()}"
             else:
-                kwargs["to"] = self.remote_field.model.lower()
+                kwargs["to"] = self.remote_field.model_ref.lower()
         else:
-            kwargs["to"] = self.remote_field.model.model_options.label_lower
+            kwargs["to"] = self.remote_field.model_ref.model_options.label_lower
 
-        if isinstance(self.remote_field.through, str):
-            kwargs["through"] = self.remote_field.through
+        if isinstance(self.remote_field.through_ref, str):
+            kwargs["through"] = self.remote_field.through_ref
         else:
-            kwargs["through"] = self.remote_field.through.model_options.label
+            kwargs["through"] = self.remote_field.through_ref.model_options.label
 
         return name, path, args, kwargs
 
@@ -990,12 +986,12 @@ class ManyToManyField(RelatedField):
         def resolve_through_model(
             _: Any, model: type[Model], field: ManyToManyField
         ) -> None:
-            field.remote_field.through = model
+            field.remote_field.through_ref = model
 
         lazy_related_operation(
             resolve_through_model,
             cls,
-            self.remote_field.through,
+            self.remote_field.through_ref,
             field=self,
         )
 

--- a/plain-postgres/plain/postgres/fields/related.py
+++ b/plain-postgres/plain/postgres/fields/related.py
@@ -189,13 +189,11 @@ class RelatedField(FieldCacheMixin, Field):
 
     def _check_clashes(self) -> list[PreflightResult]:
         """Check accessor and reverse query name clashes."""
-        from plain.postgres.base import ModelBase
-
         errors: list[PreflightResult] = []
 
-        # f.remote_field.model may be a string instead of a model. Skip if
-        # model name is not resolved.
-        if not isinstance(self.remote_field.model, ModelBase):
+        # Skip if the target model is still an unresolved string reference;
+        # _check_relation_model_exists reports that case.
+        if isinstance(self.remote_field.model_ref, str):
             return []
 
         # Consider that we are checking field `Model.foreign` and the models
@@ -636,14 +634,17 @@ class ManyToManyField(RelatedField):
     def _check_relationship_model(
         self, from_model: type[Model] | None = None, **kwargs: Any
     ) -> list[PreflightResult]:
-        if hasattr(self.remote_field.through, "_model_meta"):
-            qualified_model_name = f"{self.remote_field.through.model_options.package_label}.{self.remote_field.through.__name__}"
+        through_ref = self.remote_field.through_ref
+        if isinstance(through_ref, str):
+            qualified_model_name = through_ref
         else:
-            qualified_model_name = self.remote_field.through
+            qualified_model_name = (
+                f"{through_ref.model_options.package_label}.{through_ref.__name__}"
+            )
 
         errors = []
 
-        if self.remote_field.through not in self.meta.models_registry.get_models():
+        if through_ref not in self.meta.models_registry.get_models():
             # The relationship model is not installed.
             errors.append(
                 PreflightResult(
@@ -664,7 +665,7 @@ class ManyToManyField(RelatedField):
                 "where the field is attached to."
             )
             # Set some useful local variables
-            to_model = resolve_relation(from_model, self.remote_field.model)
+            to_model = resolve_relation(from_model, self.remote_field.model_ref)
             from_model_name = from_model.model_options.object_name
             if isinstance(to_model, str):
                 to_model_name = to_model
@@ -677,7 +678,7 @@ class ManyToManyField(RelatedField):
             # Count foreign keys in intermediate model
             if self_referential:
                 seen_self = sum(
-                    from_model == field.remote_field.model
+                    from_model == field.remote_field.model_ref
                     for field in self.remote_field.through._model_meta.fields
                     if isinstance(field, RelatedField)
                 )
@@ -700,12 +701,12 @@ class ManyToManyField(RelatedField):
             else:
                 # Count foreign keys in relationship model
                 seen_from = sum(
-                    from_model == field.remote_field.model
+                    from_model == field.remote_field.model_ref
                     for field in self.remote_field.through._model_meta.fields
                     if isinstance(field, RelatedField)
                 )
                 seen_to = sum(
-                    to_model == field.remote_field.model
+                    to_model == field.remote_field.model_ref
                     for field in self.remote_field.through._model_meta.fields
                     if isinstance(field, RelatedField)
                 )
@@ -793,7 +794,7 @@ class ManyToManyField(RelatedField):
                 source, through, target = (
                     from_model,
                     self.remote_field.through,
-                    self.remote_field.model,
+                    self.remote_field.model_ref,
                 )
                 source_field_name, target_field_name = self.remote_field.through_fields[
                     :2
@@ -803,18 +804,24 @@ class ManyToManyField(RelatedField):
                     (source_field_name, source),
                     (target_field_name, target),
                 ):
+                    # The target may still be an unresolved "package.Model" string.
+                    related_model_name = (
+                        related_model
+                        if isinstance(related_model, str)
+                        else related_model.model_options.object_name
+                    )
                     possible_field_names: list[str] = []
                     for f in through._model_meta.fields:
                         if (
-                            hasattr(f, "remote_field")
-                            and getattr(f.remote_field, "model", None) == related_model
+                            isinstance(f, RelatedField)
+                            and f.remote_field.model_ref == related_model
                         ):
                             possible_field_names.append(f.name)
                     if possible_field_names:
                         fix = (
                             "Did you mean one of the following foreign keys to '{}': "
                             "{}?".format(
-                                related_model.model_options.object_name,
+                                related_model_name,
                                 ", ".join(possible_field_names),
                             )
                         )
@@ -834,11 +841,11 @@ class ManyToManyField(RelatedField):
                     else:
                         if not (
                             isinstance(field, RelatedField)
-                            and field.remote_field.model == related_model
+                            and field.remote_field.model_ref == related_model
                         ):
                             errors.append(
                                 PreflightResult(
-                                    fix=f"'{through.model_options.object_name}.{field_name}' is not a foreign key to '{related_model.model_options.object_name}'. {fix}",
+                                    fix=f"'{through.model_options.object_name}.{field_name}' is not a foreign key to '{related_model_name}'. {fix}",
                                     obj=self,
                                     id="fields.m2m_through_field_not_fk_to_model",
                                 )

--- a/plain-postgres/plain/postgres/fields/reverse_related.py
+++ b/plain-postgres/plain/postgres/fields/reverse_related.py
@@ -81,8 +81,10 @@ class ForeignObjectRel(FieldCacheMixin):
     @property
     def model(self) -> type[Model]:
         """The resolved target model class."""
+        # Deliberately not AttributeError: getattr(rel, "model", None) and
+        # hasattr() would swallow that and silently report "no model".
         if isinstance(self.model_ref, str):
-            raise AttributeError(
+            raise TypeError(
                 f"Related model {self.model_ref!r} for {self.field!r} has not been "
                 "resolved yet; use model_ref to read the unresolved reference."
             )
@@ -254,8 +256,9 @@ class ManyToManyRel(ForeignObjectRel):
     @property
     def through(self) -> type[Model]:
         """The resolved intermediary model class."""
+        # Deliberately not AttributeError, for the same reason as `model`.
         if isinstance(self.through_ref, str):
-            raise AttributeError(
+            raise TypeError(
                 f"Through model {self.through_ref!r} for {self.field!r} has not been "
                 "resolved yet; use through_ref to read the unresolved reference."
             )

--- a/plain-postgres/plain/postgres/fields/reverse_related.py
+++ b/plain-postgres/plain/postgres/fields/reverse_related.py
@@ -49,8 +49,11 @@ class ForeignObjectRel(FieldCacheMixin):
     empty_strings_allowed = False
 
     # Type annotations for instance attributes
-    model: type[Model]
     on_delete: OnDelete | None
+    # The target model as given to the field: a "package.Model" string (or
+    # "self") until lazy_related_operation resolves it to the class. Read
+    # `model` for the resolved class.
+    model_ref: str | type[Model]
 
     def __init__(
         self,
@@ -65,9 +68,7 @@ class ForeignObjectRel(FieldCacheMixin):
         # route every `self.field` read through its __get__. ForeignKeyRel
         # and ManyToManyRel below narrow this further, the same way.
         self.field: RelatedField = field
-        # Initially may be a string, gets resolved to type[Model] by lazy_related_operation
-        # (see related.py:250 where field.remote_field.model is overwritten)
-        self.model = to  # ty: ignore[invalid-assignment]
+        self.model_ref = to
         self.related_query_name = related_query_name
         self.on_delete = on_delete
 
@@ -77,6 +78,16 @@ class ForeignObjectRel(FieldCacheMixin):
     # __init__ as the field doesn't have its model yet. Calling these methods
     # before field.contribute_to_class() has been called will result in
     # AttributeError
+    @property
+    def model(self) -> type[Model]:
+        """The resolved target model class."""
+        if isinstance(self.model_ref, str):
+            raise AttributeError(
+                f"Related model {self.model_ref!r} for {self.field!r} has not been "
+                "resolved yet; use model_ref to read the unresolved reference."
+            )
+        return self.model_ref
+
     @cached_property
     def name(self) -> str:
         return self.field.related_query_name()
@@ -113,7 +124,7 @@ class ForeignObjectRel(FieldCacheMixin):
     def identity(self) -> tuple[Any, ...]:
         return (
             self.field,
-            self.model,
+            self.model_ref,
             self.related_query_name,
             self.on_delete,
             self.symmetrical,
@@ -203,8 +214,10 @@ class ManyToManyRel(ForeignObjectRel):
     """
 
     # Type annotations for instance attributes
-    through: type[Model]
     through_fields: tuple[str, str] | None
+    # The intermediary model as given to the field; a string until
+    # lazy_related_operation resolves it. Read `through` for the class.
+    through_ref: str | type[Model]
 
     def __init__(
         self,
@@ -226,9 +239,7 @@ class ManyToManyRel(ForeignObjectRel):
         # annotation).
         self.field: ManyToManyField
 
-        # Initially may be a string, gets resolved to type[Model] by lazy_related_operation
-        # (see related.py:1143 where field.remote_field.through is overwritten)
-        self.through = through  # ty: ignore[invalid-assignment]
+        self.through_ref = through
         self.through_fields = through_fields
 
         self.symmetrical = symmetrical
@@ -236,6 +247,16 @@ class ManyToManyRel(ForeignObjectRel):
     @property
     def identity(self) -> tuple[Any, ...]:
         return super().identity + (
-            self.through,
+            self.through_ref,
             make_hashable(self.through_fields),
         )
+
+    @property
+    def through(self) -> type[Model]:
+        """The resolved intermediary model class."""
+        if isinstance(self.through_ref, str):
+            raise AttributeError(
+                f"Through model {self.through_ref!r} for {self.field!r} has not been "
+                "resolved yet; use through_ref to read the unresolved reference."
+            )
+        return self.through_ref

--- a/plain-postgres/plain/postgres/meta.py
+++ b/plain-postgres/plain/postgres/meta.py
@@ -178,11 +178,10 @@ class Meta:
         # ideally, we'd just ask for field.related_model. However, related_model
         # is a cached property, and all the models haven't been loaded yet, so
         # we need to make sure we don't cache a string reference.
-        if isinstance(field, RelatedField) and field.remote_field.model:
-            try:
-                field.remote_field.model._model_meta._expire_cache(forward=False)
-            except AttributeError:
-                pass
+        if isinstance(field, RelatedField):
+            remote_model = field.remote_field.model_ref
+            if not isinstance(remote_model, str):
+                remote_model._model_meta._expire_cache(forward=False)
             self._expire_cache()
         else:
             self._expire_cache(reverse=False)
@@ -326,8 +325,8 @@ class Meta:
                 if isinstance(f, RelatedField)
             )
             for f in fields_with_relations:
-                if not isinstance(f.remote_field.model, str):
-                    remote_label = f.remote_field.model.model_options.label
+                if not isinstance(f.remote_field.model_ref, str):
+                    remote_label = f.remote_field.model_ref.model_options.label
                     related_objects_graph[remote_label].append(f)
 
         for model in all_models:

--- a/plain-postgres/plain/postgres/migrations/autodetector.py
+++ b/plain-postgres/plain/postgres/migrations/autodetector.py
@@ -892,8 +892,10 @@ class MigrationAutodetector:
                     package_label,
                     model_name,
                 )
-                if rename_key in self.renamed_models:
-                    new_field.remote_field.model_ref = old_field.remote_field.model_ref  # ty: ignore[unresolved-attribute]
+                if rename_key in self.renamed_models and isinstance(
+                    old_field, RelatedField
+                ):
+                    new_field.remote_field.model_ref = old_field.remote_field.model_ref
                 dependencies.extend(
                     self._get_dependencies_for_foreign_key(
                         package_label,
@@ -908,8 +910,12 @@ class MigrationAutodetector:
                     package_label,
                     model_name,
                 )
-                if rename_key in self.renamed_models:
-                    new_field.remote_field.through_ref = old_field.remote_field.through_ref  # ty: ignore[unresolved-attribute]
+                if rename_key in self.renamed_models and isinstance(
+                    old_field, ManyToManyField
+                ):
+                    new_field.remote_field.through_ref = (
+                        old_field.remote_field.through_ref
+                    )
             old_field_dec = self.deep_deconstruct(old_field)
             new_field_dec = self.deep_deconstruct(new_field)
             # Exclude non_migration_attrs (allow_null, default, on_delete, choices,

--- a/plain-postgres/plain/postgres/migrations/autodetector.py
+++ b/plain-postgres/plain/postgres/migrations/autodetector.py
@@ -244,11 +244,9 @@ class MigrationAutodetector:
             )
             old_model_state = self.from_state.models[package_label, old_model_name]
             for field_name, field in old_model_state.fields.items():
-                if hasattr(field, "remote_field") and getattr(
-                    field.remote_field, "through", None
-                ):
+                if isinstance(field, ManyToManyField):
                     through_key = resolve_relation(
-                        field.remote_field.through_ref,  # ty: ignore[unresolved-attribute]
+                        field.remote_field.through_ref,
                         package_label,
                         model_name,
                     )
@@ -888,11 +886,9 @@ class MigrationAutodetector:
             dependencies: list[tuple[str, str, str | None, bool | str]] = []
             # Implement any model renames on relations; these are handled by RenameModel
             # so we need to exclude them from the comparison
-            if hasattr(new_field, "remote_field") and getattr(
-                new_field.remote_field, "model", None
-            ):
+            if isinstance(new_field, RelatedField):
                 rename_key = resolve_relation(
-                    new_field.remote_field.model_ref,  # ty: ignore[unresolved-attribute]
+                    new_field.remote_field.model_ref,
                     package_label,
                     model_name,
                 )
@@ -906,11 +902,9 @@ class MigrationAutodetector:
                         self.to_state,
                     )
                 )
-            if hasattr(new_field, "remote_field") and getattr(
-                new_field.remote_field, "through", None
-            ):
+            if isinstance(new_field, ManyToManyField):
                 rename_key = resolve_relation(
-                    new_field.remote_field.through_ref,  # ty: ignore[unresolved-attribute]
+                    new_field.remote_field.through_ref,
                     package_label,
                     model_name,
                 )

--- a/plain-postgres/plain/postgres/migrations/autodetector.py
+++ b/plain-postgres/plain/postgres/migrations/autodetector.py
@@ -139,7 +139,7 @@ class MigrationAutodetector:
         fields_def = []
         for name, field in sorted(fields.items()):
             deconstruction = self.deep_deconstruct(field)
-            if isinstance(field, RelatedField) and field.remote_field.model:
+            if isinstance(field, RelatedField) and field.remote_field.model_ref:
                 deconstruction[2].pop("to", None)
             fields_def.append(deconstruction)
         return fields_def
@@ -248,7 +248,7 @@ class MigrationAutodetector:
                     field.remote_field, "through", None
                 ):
                     through_key = resolve_relation(
-                        field.remote_field.through,  # ty: ignore[unresolved-attribute]
+                        field.remote_field.through_ref,  # ty: ignore[unresolved-attribute]
                         package_label,
                         model_name,
                     )
@@ -537,7 +537,7 @@ class MigrationAutodetector:
             related_fields = {}
             for field_name, field in model_state.fields.items():
                 if isinstance(field, RelatedField):
-                    if field.remote_field.model:
+                    if field.remote_field.model_ref:
                         related_fields[field_name] = field
                     if isinstance(field.remote_field, ManyToManyRel):
                         related_fields[field_name] = field
@@ -639,7 +639,7 @@ class MigrationAutodetector:
             related_fields = {}
             for field_name, field in model_state.fields.items():
                 if isinstance(field, RelatedField):
-                    if field.remote_field.model:
+                    if field.remote_field.model_ref:
                         related_fields[field_name] = field
                     if isinstance(field.remote_field, ManyToManyRel):
                         related_fields[field_name] = field
@@ -720,7 +720,7 @@ class MigrationAutodetector:
                     if (
                         isinstance(field, RelatedField)
                         and field.remote_field
-                        and field.remote_field.model
+                        and field.remote_field.model_ref
                         and "to" in old_field_dec[2]
                     ):
                         old_rel_to = old_field_dec[2]["to"]
@@ -790,7 +790,7 @@ class MigrationAutodetector:
             (package_label, model_name, field_name, False)
         ]
         # Fields that are foreignkeys/m2ms depend on stuff.
-        if isinstance(field, RelatedField) and field.remote_field.model:
+        if isinstance(field, RelatedField) and field.remote_field.model_ref:
             dependencies.extend(
                 self._get_dependencies_for_foreign_key(
                     package_label,
@@ -892,12 +892,12 @@ class MigrationAutodetector:
                 new_field.remote_field, "model", None
             ):
                 rename_key = resolve_relation(
-                    new_field.remote_field.model,  # ty: ignore[unresolved-attribute]
+                    new_field.remote_field.model_ref,  # ty: ignore[unresolved-attribute]
                     package_label,
                     model_name,
                 )
                 if rename_key in self.renamed_models:
-                    new_field.remote_field.model = old_field.remote_field.model  # ty: ignore[unresolved-attribute]
+                    new_field.remote_field.model_ref = old_field.remote_field.model_ref  # ty: ignore[unresolved-attribute]
                 dependencies.extend(
                     self._get_dependencies_for_foreign_key(
                         package_label,
@@ -910,12 +910,12 @@ class MigrationAutodetector:
                 new_field.remote_field, "through", None
             ):
                 rename_key = resolve_relation(
-                    new_field.remote_field.through,  # ty: ignore[unresolved-attribute]
+                    new_field.remote_field.through_ref,  # ty: ignore[unresolved-attribute]
                     package_label,
                     model_name,
                 )
                 if rename_key in self.renamed_models:
-                    new_field.remote_field.through = old_field.remote_field.through  # ty: ignore[unresolved-attribute]
+                    new_field.remote_field.through_ref = old_field.remote_field.through_ref  # ty: ignore[unresolved-attribute]
             old_field_dec = self.deep_deconstruct(old_field)
             new_field_dec = self.deep_deconstruct(new_field)
             # Exclude non_migration_attrs (allow_null, default, on_delete, choices,
@@ -1004,7 +1004,7 @@ class MigrationAutodetector:
     ) -> list[tuple[str, str, str | None, bool | str]]:
         remote_field_model = None
         if isinstance(field, RelatedField):
-            remote_field_model = field.remote_field.model
+            remote_field_model = field.remote_field.model_ref
         else:
             relations = project_state.relations[package_label, model_name]
             for (remote_package_label, remote_model_name), fields in relations.items():
@@ -1027,7 +1027,7 @@ class MigrationAutodetector:
             field.remote_field, ManyToManyRel
         ):
             through_package_label, through_object_name = resolve_relation(
-                field.remote_field.through,
+                field.remote_field.through_ref,
                 package_label,
                 model_name,
             )

--- a/plain-postgres/plain/postgres/migrations/state.py
+++ b/plain-postgres/plain/postgres/migrations/state.py
@@ -449,7 +449,11 @@ class ProjectState:
             concretes,
         )
 
-        through = remote_field.through_ref if isinstance(remote_field, ManyToManyRel) else None
+        through = (
+            remote_field.through_ref
+            if isinstance(remote_field, ManyToManyRel)
+            else None
+        )
         if not through:
             return
         self.update_model_field_relation(
@@ -648,7 +652,7 @@ class ModelState:
             if isinstance(field, RelatedField) and not isinstance(
                 field.remote_field.model_ref, str
             ):
-                raise ValueError(
+                raise TypeError(
                     f'ModelState.fields cannot refer to a model class - "{name}.to" does. '
                     "Use a string reference instead."
                 )
@@ -657,7 +661,7 @@ class ModelState:
             if isinstance(field, ManyToManyField) and not isinstance(
                 field.remote_field.through_ref, str
             ):
-                raise ValueError(
+                raise TypeError(
                     f'ModelState.fields cannot refer to a model class - "{name}.through" '
                     "does. Use a string reference instead."
                 )

--- a/plain-postgres/plain/postgres/migrations/state.py
+++ b/plain-postgres/plain/postgres/migrations/state.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 from plain.packages import packages_registry
 from plain.postgres.exceptions import FieldDoesNotExist
 from plain.postgres.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT, RelatedField
+from plain.postgres.fields.reverse_related import ManyToManyRel
 from plain.postgres.meta import Meta
 from plain.postgres.migrations.utils import field_is_referenced, get_references
 from plain.postgres.registry import ModelsRegistry
@@ -448,7 +449,7 @@ class ProjectState:
             concretes,
         )
 
-        through = getattr(remote_field, "through", None)
+        through = remote_field.through_ref if isinstance(remote_field, ManyToManyRel) else None
         if not through:
             return
         self.update_model_field_relation(

--- a/plain-postgres/plain/postgres/migrations/state.py
+++ b/plain-postgres/plain/postgres/migrations/state.py
@@ -48,12 +48,11 @@ def _get_related_models(m: type[postgres.Model]) -> list[type[postgres.Model]]:
     ]
     from plain.postgres.fields.reverse_related import ForeignObjectRel
 
-    related_fields_models = set()
     for f in m._model_meta.get_fields(include_reverse=True):
-        if isinstance(f, RelatedField | ForeignObjectRel) and not isinstance(
-            f.related_model, str
-        ):
-            related_fields_models.add(f.model)
+        if isinstance(f, RelatedField):
+            if not isinstance(f.remote_field.model_ref, str):
+                related_models.append(f.remote_field.model_ref)
+        elif isinstance(f, ForeignObjectRel):
             related_models.append(f.related_model)
     return related_models
 
@@ -170,12 +169,12 @@ class ProjectState:
             if reference.to:
                 changed_field = field.clone()
                 assert changed_field.remote_field is not None
-                changed_field.remote_field.model = new_remote_model  # ty: ignore[invalid-assignment]
+                changed_field.remote_field.model_ref = new_remote_model
             if reference.through:
                 if changed_field is None:
                     changed_field = field.clone()
                 assert changed_field.remote_field is not None
-                changed_field.remote_field.through = new_remote_model  # ty: ignore[unresolved-attribute]
+                changed_field.remote_field.through_ref = new_remote_model  # ty: ignore[unresolved-attribute]
             if changed_field:
                 model_state.fields[name] = changed_field
                 to_reload.add((model_state.package_label, model_state.name_lower))
@@ -328,10 +327,10 @@ class ProjectState:
         direct_related_models = set()
         for field in model_state.fields.values():
             if isinstance(field, RelatedField):
-                if field.remote_field.model == RECURSIVE_RELATIONSHIP_CONSTANT:
+                if field.remote_field.model_ref == RECURSIVE_RELATIONSHIP_CONSTANT:
                     continue
                 rel_package_label, rel_model_name = _get_package_label_and_model_name(
-                    field.related_model,
+                    field.remote_field.model_ref,
                     package_label,
                 )
                 direct_related_models.add((rel_package_label, rel_model_name.lower()))
@@ -442,7 +441,7 @@ class ProjectState:
             concretes = self._get_concrete_models_mapping()
 
         self.update_model_field_relation(
-            remote_field.model,
+            remote_field.model_ref,
             model_key,
             field_name,
             field,
@@ -645,8 +644,8 @@ class ModelState:
                     f'ModelState.fields cannot be bound to a model - "{field_name}" is.'
                 )
             # Sanity-check that relation fields are NOT referring to a model class.
-            if isinstance(field, RelatedField) and hasattr(
-                field.related_model, "_model_meta"
+            if isinstance(field, RelatedField) and not isinstance(
+                field.remote_field.model_ref, str
             ):
                 raise ValueError(
                     f'ModelState.fields cannot refer to a model class - "{name}.to" does. '
@@ -654,8 +653,8 @@ class ModelState:
                 )
             from plain.postgres.fields.related import ManyToManyField
 
-            if isinstance(field, ManyToManyField) and hasattr(
-                field.remote_field.through, "_model_meta"
+            if isinstance(field, ManyToManyField) and not isinstance(
+                field.remote_field.through_ref, str
             ):
                 raise ValueError(
                     f'ModelState.fields cannot refer to a model class - "{name}.through" '

--- a/plain-postgres/plain/postgres/migrations/utils.py
+++ b/plain-postgres/plain/postgres/migrations/utils.py
@@ -94,13 +94,17 @@ def field_references(
     references_to = None
     references_through = None
     # ForeignObject always references 'id'
-    if resolve_relation(remote_field.model_ref, *model_tuple) == reference_model_tuple and (
+    if resolve_relation(
+        remote_field.model_ref, *model_tuple
+    ) == reference_model_tuple and (
         reference_field_name is None
         or reference_field_name == "id"
         or (reference_field is None or reference_field.primary_key)
     ):
         references_to = (remote_field, ["id"])
-    through = remote_field.through_ref if isinstance(remote_field, ManyToManyRel) else None
+    through = (
+        remote_field.through_ref if isinstance(remote_field, ManyToManyRel) else None
+    )
     if through and resolve_relation(through, *model_tuple) == reference_model_tuple:
         through_fields = getattr(remote_field, "through_fields", None)
         if (

--- a/plain-postgres/plain/postgres/migrations/utils.py
+++ b/plain-postgres/plain/postgres/migrations/utils.py
@@ -93,7 +93,7 @@ def field_references(
     references_to = None
     references_through = None
     # ForeignObject always references 'id'
-    if resolve_relation(remote_field.model, *model_tuple) == reference_model_tuple and (
+    if resolve_relation(remote_field.model_ref, *model_tuple) == reference_model_tuple and (
         reference_field_name is None
         or reference_field_name == "id"
         or (reference_field is None or reference_field.primary_key)

--- a/plain-postgres/plain/postgres/migrations/utils.py
+++ b/plain-postgres/plain/postgres/migrations/utils.py
@@ -8,6 +8,7 @@ from plain.postgres.fields.related import (
     RECURSIVE_RELATIONSHIP_CONSTANT,
     RelatedField,
 )
+from plain.postgres.fields.reverse_related import ManyToManyRel
 from plain.utils import timezone
 
 if TYPE_CHECKING:
@@ -99,7 +100,7 @@ def field_references(
         or (reference_field is None or reference_field.primary_key)
     ):
         references_to = (remote_field, ["id"])
-    through = getattr(remote_field, "through", None)
+    through = remote_field.through_ref if isinstance(remote_field, ManyToManyRel) else None
     if through and resolve_relation(through, *model_tuple) == reference_model_tuple:
         through_fields = getattr(remote_field, "through_fields", None)
         if (

--- a/plain-postgres/tests/internal/test_unresolved_relation_refs.py
+++ b/plain-postgres/tests/internal/test_unresolved_relation_refs.py
@@ -1,0 +1,128 @@
+"""A relation holds a "package.Model" string until lazy resolution swaps in
+the class. The code that runs before that point (preflight, migration state,
+the autodetector) must read the raw reference, and the resolved accessors
+must fail loudly rather than be silently skipped by getattr()/hasattr()."""
+
+from __future__ import annotations
+
+import pytest
+from plain.postgres import types
+from plain.postgres.deletion import CASCADE
+from plain.postgres.fields.related import ForeignKeyField, ManyToManyField
+from plain.postgres.migrations.autodetector import MigrationAutodetector
+from plain.postgres.migrations.state import ModelState, ProjectState
+from plain.postgres.migrations.utils import field_references
+from plain.postgres.registry import ModelsRegistry
+
+
+def test_unresolved_model_is_not_swallowed_by_getattr():
+    field = types.ForeignKeyField("examples.Missing", on_delete=CASCADE)
+    rel = field.remote_field
+
+    assert rel.model_ref == "examples.Missing"
+    with pytest.raises(TypeError, match="not been resolved"):
+        rel.model
+    # getattr()/hasattr() only swallow AttributeError, so a probe can never
+    # quietly answer "no model" for a reference that just isn't resolved yet.
+    with pytest.raises(TypeError):
+        getattr(rel, "model", None)
+
+
+def test_unresolved_through_is_not_swallowed_by_getattr():
+    field = ManyToManyField("examples.Missing", through="examples.MissingThrough")
+    rel = field.remote_field
+
+    assert rel.through_ref == "examples.MissingThrough"
+    with pytest.raises(TypeError, match="not been resolved"):
+        rel.through
+    with pytest.raises(TypeError):
+        hasattr(rel, "through")
+
+
+def _tagging_state() -> ProjectState:
+    """Post <-M2M through Tagging-> Tag, declared with string references only."""
+    state = ProjectState()
+    state.add_model(
+        ModelState(
+            package_label="examples",
+            name="Tag",
+            fields=[("name", types.TextField())],
+        )
+    )
+    state.add_model(
+        ModelState(
+            package_label="examples",
+            name="Tagging",
+            fields=[
+                ("post", types.ForeignKeyField("examples.Post", on_delete=CASCADE)),
+                ("tag", types.ForeignKeyField("examples.Tag", on_delete=CASCADE)),
+            ],
+        )
+    )
+    state.add_model(
+        ModelState(
+            package_label="examples",
+            name="Post",
+            fields=[
+                ("tags", ManyToManyField("examples.Tag", through="examples.Tagging")),
+            ],
+        )
+    )
+    return state
+
+
+def test_field_references_sees_string_through_model():
+    m2m = ManyToManyField("examples.Tag", through="examples.Tagging")
+
+    assert field_references(("examples", "post"), m2m, ("examples", "tagging"))
+    assert field_references(("examples", "post"), m2m, ("examples", "tag"))
+    assert not field_references(("examples", "post"), m2m, ("examples", "other"))
+
+
+def test_project_state_relations_index_string_through_model():
+    relations = _tagging_state().relations
+
+    assert "tags" in relations[("examples", "tagging")][("examples", "post")]
+    assert "tags" in relations[("examples", "tag")][("examples", "post")]
+
+
+def test_autodetector_maps_string_through_model_users():
+    autodetector = MigrationAutodetector(_tagging_state(), _tagging_state())
+    autodetector._detect_changes()
+
+    assert autodetector.through_users[("examples", "tagging")] == (
+        "examples",
+        "post",
+        "tags",
+    )
+
+
+def test_preflight_reports_unresolved_relations_instead_of_crashing():
+    """Render onto a bare registry so the missing targets stay unresolved:
+    the state preflight sees when a model declares a relation to a typo."""
+    registry = ModelsRegistry()
+    ModelState(
+        package_label="examples",
+        name="Tag",
+        fields=[("name", types.TextField())],
+    ).render(registry)
+    post = ModelState(
+        package_label="examples",
+        name="Post",
+        fields=[
+            ("author", types.ForeignKeyField("examples.Missing", on_delete=CASCADE)),
+            ("tags", ManyToManyField("examples.Tag", through="examples.MissingThrough")),
+        ],
+    ).render(registry)
+    registry.ready = True
+
+    author = post._model_meta.get_forward_field("author")
+    assert isinstance(author, ForeignKeyField)
+    assert isinstance(author.remote_field.model_ref, str)
+    assert "fields.related_model_not_installed" in {r.id for r in author.preflight()}
+
+    (tags,) = post._model_meta.many_to_many
+    assert isinstance(tags.remote_field.through_ref, str)
+    assert "fields.m2m_through_model_not_installed" in {
+        r.id for r in tags.preflight(from_model=post)
+    }

--- a/plain-postgres/tests/internal/test_unresolved_relation_refs.py
+++ b/plain-postgres/tests/internal/test_unresolved_relation_refs.py
@@ -112,17 +112,30 @@ def test_preflight_reports_unresolved_relations_instead_of_crashing():
         fields=[
             ("author", types.ForeignKeyField("examples.Missing", on_delete=CASCADE)),
             ("tags", ManyToManyField("examples.Tag", through="examples.MissingThrough")),
+            (
+                "labels",
+                ManyToManyField("examples.MissingTarget", through="examples.Labeling"),
+            ),
         ],
     ).render(registry)
     registry.ready = True
+
+    # The model-level entry point `plain preflight` uses must not blow up.
+    model_ids = {r.id for r in post.preflight()}
+    assert "fields.related_model_not_installed" in model_ids
+    assert "fields.m2m_through_model_not_installed" in model_ids
 
     author = post._model_meta.get_forward_field("author")
     assert isinstance(author, ForeignKeyField)
     assert isinstance(author.remote_field.model_ref, str)
     assert "fields.related_model_not_installed" in {r.id for r in author.preflight()}
 
-    (tags,) = post._model_meta.many_to_many
+    labels, tags = post._model_meta.many_to_many
     assert isinstance(tags.remote_field.through_ref, str)
     assert "fields.m2m_through_model_not_installed" in {
         r.id for r in tags.preflight(from_model=post)
+    }
+    assert isinstance(labels.remote_field.model_ref, str)
+    assert "fields.related_model_not_installed" in {
+        r.id for r in labels.preflight(from_model=post)
     }

--- a/plain-postgres/tests/internal/test_unresolved_relation_refs.py
+++ b/plain-postgres/tests/internal/test_unresolved_relation_refs.py
@@ -21,7 +21,7 @@ def test_unresolved_model_is_not_swallowed_by_getattr():
 
     assert rel.model_ref == "examples.Missing"
     with pytest.raises(TypeError, match="not been resolved"):
-        rel.model
+        _ = rel.model
     # getattr()/hasattr() only swallow AttributeError, so a probe can never
     # quietly answer "no model" for a reference that just isn't resolved yet.
     with pytest.raises(TypeError):
@@ -34,7 +34,7 @@ def test_unresolved_through_is_not_swallowed_by_getattr():
 
     assert rel.through_ref == "examples.MissingThrough"
     with pytest.raises(TypeError, match="not been resolved"):
-        rel.through
+        _ = rel.through
     with pytest.raises(TypeError):
         hasattr(rel, "through")
 
@@ -111,7 +111,10 @@ def test_preflight_reports_unresolved_relations_instead_of_crashing():
         name="Post",
         fields=[
             ("author", types.ForeignKeyField("examples.Missing", on_delete=CASCADE)),
-            ("tags", ManyToManyField("examples.Tag", through="examples.MissingThrough")),
+            (
+                "tags",
+                ManyToManyField("examples.Tag", through="examples.MissingThrough"),
+            ),
             (
                 "labels",
                 ManyToManyField("examples.MissingTarget", through="examples.Labeling"),


### PR DESCRIPTION
Follow-up to #103.

`ForeignObjectRel.model` and `ManyToManyRel.through` were annotated `type[Model]` but held a `"package.Model"` string from construction until `lazy_related_operation` resolved them, which is why the assignments in `__init__` and the migration-state repointing needed `# ty: ignore`. Meanwhile, every one of the ~90 reads in query compilation, descriptors, and managers correctly expected a class, and 8 sites had to `isinstance(…, str)` to tell which phase they were in.

This makes the two phases explicit:

- `rel.model_ref: str | type[Model]` and `rel.through_ref: str | type[Model]` hold whatever the field was given. This is what the lazy resolver writes to, what `deconstruct()` and `identity` read, and what preflight, the migration autodetector, and project state work with, since those run before resolution or on model states whose targets are always strings.
- `rel.model` and `rel.through` are now properties that return the resolved class, and raise `TypeError` if read before resolution. The ~90 existing reads are unchanged and now honestly typed.

## Second commit: the review findings

The first commit raised `AttributeError` from the properties. Codex flagged 8 places where that silently broke things, and they were all real: this codebase probes relations with `getattr(rel, "through", None)` and `hasattr(...)`, which swallow exactly that exception, so the migration autodetector's through-model map, `ProjectState.relations`, `field_references()`, and the M2M through-field validation all quietly answered "no relation". Preflight's `_check_clashes` and `_check_relationship_model` also still read the resolved accessor on targets that may not exist yet.

- The properties now raise `TypeError`, which `getattr`/`hasattr` cannot swallow.
- Every probe is replaced by `isinstance(field, RelatedField | ManyToManyField)` or `isinstance(rel, ManyToManyRel)` followed by a read of the `_ref` attribute.
- Preflight paths read `model_ref` / `through_ref` and format an unresolved target by its string.
- New `tests/internal/test_unresolved_relation_refs.py` covers all of it: the raise type, `field_references()` with a string through, `ProjectState.relations` and the autodetector's through-model map built from string references, and preflight on a model whose FK target and M2M through model don't exist. All six fail on the first commit and pass on the second.

That the original suite passed with those paths broken is the real lesson here: nothing exercised migration state with a string `through`, or preflight against a missing target model. These tests close that gap.

No changes outside `plain-postgres`; nothing else in the repo reads these attributes.

Type ignores 148 → 140.

## Test plan

- [x] `./scripts/type-validate` 26/26
- [x] `./scripts/test` across all packages
- [x] New tests confirmed failing on the previous head