### PR TITLE
Collapse Meta field collections to fields and many_to_many

### DIFF
--- a/plain-postgres/plain/postgres/base.py
+++ b/plain-postgres/plain/postgres/base.py
@@ -188,16 +188,14 @@ class Model(metaclass=ModelBase):
 
     @classmethod
     def from_db(cls, field_names: Iterable[str], values: Sequence[Any]) -> Model:
-        if len(values) != len(cls._model_meta.concrete_fields):
+        if len(values) != len(cls._model_meta.fields):
             values_iter = iter(values)
             values = [
                 next(values_iter) if f.name in field_names else DEFERRED
-                for f in cls._model_meta.concrete_fields
+                for f in cls._model_meta.fields
             ]
         # Build kwargs dict from field names and values
-        field_dict = dict(
-            zip((f.name for f in cls._model_meta.concrete_fields), values)
-        )
+        field_dict = dict(zip((f.name for f in cls._model_meta.fields), values))
         new = cls(_from_db=True, **field_dict)
         new._state.adding = False
         return new
@@ -274,11 +272,7 @@ class Model(metaclass=ModelBase):
         """
         Return a set containing names of deferred fields for this instance.
         """
-        return {
-            f.name
-            for f in self._model_meta.concrete_fields
-            if f.name not in self.__dict__
-        }
+        return {f.name for f in self._model_meta.fields if f.name not in self.__dict__}
 
     def refresh_from_db(self, fields: list[str] | None = None) -> None:
         """
@@ -315,15 +309,13 @@ class Model(metaclass=ModelBase):
             db_instance_qs = db_instance_qs.only(*fields)
         elif deferred_fields:
             fields = [
-                f.name
-                for f in self._model_meta.concrete_fields
-                if f.name not in deferred_fields
+                f.name for f in self._model_meta.fields if f.name not in deferred_fields
             ]
             db_instance_qs = db_instance_qs.only(*fields)
 
         db_instance = db_instance_qs.get()
         non_loaded_fields = db_instance.get_deferred_fields()
-        for field in self._model_meta.concrete_fields:
+        for field in self._model_meta.fields:
             if field.name in non_loaded_fields:
                 # This field wasn't refreshed - skip ahead.
                 continue
@@ -399,7 +391,7 @@ class Model(metaclass=ModelBase):
             if not fields:
                 return self  # explicit "update nothing" -- no-op
             fields = frozenset(fields)
-            field_names = self._model_meta._non_pk_concrete_field_names
+            field_names = self._model_meta._non_pk_field_names
             non_model_fields = fields.difference(field_names)
             if non_model_fields:
                 raise ValueError(
@@ -415,7 +407,7 @@ class Model(metaclass=ModelBase):
                 )
         elif deferred_fields:
             # Loaded via .only()/.defer() -- write just the loaded fields.
-            loaded = self._model_meta._non_pk_concrete_field_names - deferred_fields
+            loaded = self._model_meta._non_pk_field_names - deferred_fields
             if loaded:
                 fields = loaded
         self._prepare_related_fields_for_save(
@@ -479,7 +471,7 @@ class Model(metaclass=ModelBase):
         fields from RETURNING. Omits id from the INSERT when unset so Postgres
         generates the identity value."""
         meta = self._model_meta
-        fields = list(meta.local_concrete_fields)
+        fields = list(meta.fields)
         if self.id is None:
             id_field = meta.get_forward_field("id")
             fields = [f for f in fields if f is not id_field]
@@ -496,7 +488,7 @@ class Model(metaclass=ModelBase):
         row matched -- update() targets an existing row and has no INSERT
         fallback (that's create())."""
         meta = self._model_meta
-        non_pks = [f for f in meta.local_concrete_fields if not f.primary_key]
+        non_pks = [f for f in meta.fields if not f.primary_key]
         if fields:
             non_pks = [f for f in non_pks if f.name in fields]
         values = [(f, f.pre_save(self, False)) for f in non_pks]
@@ -519,7 +511,7 @@ class Model(metaclass=ModelBase):
     ) -> None:
         # Ensure that a model instance without a PK hasn't been assigned to
         # a ForeignKeyField on this model. If the field is nullable, allowing the save would result in silent data loss.
-        for field in self._model_meta.concrete_fields:
+        for field in self._model_meta.fields:
             if field_names and field.name not in field_names:
                 continue
             # If the related field isn't cached, then an instance hasn't been
@@ -604,7 +596,7 @@ class Model(metaclass=ModelBase):
         meta = meta or self._model_meta
         return {
             field.name: Value(field.value_from_object(self), field)
-            for field in meta.local_concrete_fields
+            for field in meta.fields
             if field.name not in exclude
         }
 
@@ -748,9 +740,9 @@ class Model(metaclass=ModelBase):
     def _check_fields(cls) -> list[PreflightResult]:
         """Perform all field checks."""
         errors: list[PreflightResult] = []
-        for field in cls._model_meta.local_fields:
+        for field in cls._model_meta.fields:
             errors.extend(field.preflight(from_model=cls))
-        for field in cls._model_meta.local_many_to_many:
+        for field in cls._model_meta.many_to_many:
             errors.extend(field.preflight(from_model=cls))
         return errors
 
@@ -761,7 +753,7 @@ class Model(metaclass=ModelBase):
         errors: list[PreflightResult] = []
         seen_intermediary_signatures = []
 
-        fields = cls._model_meta.local_many_to_many
+        fields = cls._model_meta.many_to_many
 
         # Skip when the target model wasn't found.
         fields = (f for f in fields if isinstance(f.remote_field.model, ModelBase))
@@ -793,9 +785,7 @@ class Model(metaclass=ModelBase):
     def _check_id_field(cls) -> list[PreflightResult]:
         """Disallow user-defined fields named ``id``."""
         if any(
-            f
-            for f in cls._model_meta.local_fields
-            if f.name == "id" and not f.auto_created
+            f for f in cls._model_meta.fields if f.name == "id" and not f.auto_created
         ):
             return [
                 PreflightResult(
@@ -812,7 +802,7 @@ class Model(metaclass=ModelBase):
         errors: list[PreflightResult] = []
         used_fields = {}  # name -> field
 
-        for f in cls._model_meta.local_fields:
+        for f in cls._model_meta.fields:
             clash = used_fields.get(f.name)
             # Note that we may detect clash between user-defined non-unique
             # field "id" and automatically added unique field "id", both
@@ -840,7 +830,7 @@ class Model(metaclass=ModelBase):
         used_column_names: list[str] = []
         errors: list[PreflightResult] = []
 
-        for f in cls._model_meta.local_fields:
+        for f in cls._model_meta.fields:
             column_name = f.column
 
             # Ensure the column name is not already in use.
@@ -908,7 +898,7 @@ class Model(metaclass=ModelBase):
     @classmethod
     def _check_single_primary_key(cls) -> list[PreflightResult]:
         errors: list[PreflightResult] = []
-        if sum(1 for f in cls._model_meta.local_fields if f.primary_key) > 1:
+        if sum(1 for f in cls._model_meta.fields if f.primary_key) > 1:
             errors.append(
                 PreflightResult(
                     fix="The model cannot have more than one field with "
@@ -959,11 +949,11 @@ class Model(metaclass=ModelBase):
             include for index in cls.model_options.indexes for include in index.include
         ]
         fields += references
-        errors.extend(cls._check_local_fields(fields, "indexes"))
+        errors.extend(cls._check_referenced_fields(fields, "indexes"))
         return errors
 
     @classmethod
-    def _check_local_fields(
+    def _check_referenced_fields(
         cls, fields: Iterable[str], option: str
     ) -> list[PreflightResult]:
         # In order to avoid hitting the relation tree prematurely, we use our
@@ -994,15 +984,6 @@ class Model(metaclass=ModelBase):
                             f"ManyToManyFields are not permitted in '{option}'.",
                             obj=cls,
                             id="postgres.m2m_field_in_meta_option",
-                        )
-                    )
-                elif field not in cls._model_meta.local_fields:
-                    errors.append(
-                        PreflightResult(
-                            fix=f"'{option}' refers to field '{field_name}' which is not local to model "
-                            f"'{cls.model_options.object_name}'.",
-                            obj=cls,
-                            id="postgres.non_local_field_reference",
                         )
                     )
         return errors
@@ -1114,7 +1095,7 @@ class Model(metaclass=ModelBase):
         # silently truncate, so we check for names that are too long
         allowed_len = MAX_NAME_LENGTH
 
-        for f in cls._model_meta.local_fields:
+        for f in cls._model_meta.fields:
             column_name = f.column
 
             # Check if column name is too long for the database.
@@ -1128,13 +1109,13 @@ class Model(metaclass=ModelBase):
                     )
                 )
 
-        for f in cls._model_meta.local_many_to_many:
+        for f in cls._model_meta.many_to_many:
             # Skip nonexistent models.
             if isinstance(f.remote_field.through, str):
                 continue
 
             # Check if column name for the M2M field is too long for the database.
-            for m2m in f.remote_field.through._model_meta.local_fields:
+            for m2m in f.remote_field.through._model_meta.fields:
                 rel_name = m2m.column
                 if rel_name is not None and len(rel_name) > allowed_len:
                     errors.append(
@@ -1228,7 +1209,7 @@ class Model(metaclass=ModelBase):
                         id="postgres.constraint_refers_to_joined_field",
                     )
                 )
-        errors.extend(cls._check_local_fields(fields, "constraints"))
+        errors.extend(cls._check_referenced_fields(fields, "constraints"))
         return errors
 
 

--- a/plain-postgres/plain/postgres/connection.py
+++ b/plain-postgres/plain/postgres/connection.py
@@ -535,9 +535,7 @@ class DatabaseConnection:
         tables = set()
         for model in get_migratable_models():
             tables.add(model.model_options.db_table)
-            tables.update(
-                f.m2m_db_table() for f in model._model_meta.local_many_to_many
-            )
+            tables.update(f.m2m_db_table() for f in model._model_meta.many_to_many)
         tables = list(tables)
         if only_existing:
             existing_tables = set(self.table_names(include_views=include_views))

--- a/plain-postgres/plain/postgres/convergence/analysis.py
+++ b/plain-postgres/plain/postgres/convergence/analysis.py
@@ -585,7 +585,7 @@ def _compare_columns(
     statuses: list[ColumnStatus] = []
     expected_col_names: set[str] = set()
 
-    for f in model._model_meta.local_fields:
+    for f in model._model_meta.fields:
         db_type = f.db_type()
         if db_type is None:
             continue
@@ -1188,7 +1188,7 @@ def _compare_check_constraints(
     # ignored rather than surfaced as undeclared user constraints.
     internal_checks = {
         generate_notnull_check_name(table, f.column)
-        for f in model._model_meta.local_fields
+        for f in model._model_meta.fields
         if f.db_type() is not None
     }
 
@@ -1240,7 +1240,7 @@ def _compare_foreign_keys(
     # Expected FKs from model fields, keyed by shape (column, target_table,
     # target_column) — the DB-side identity, since names can lag a rename.
     expected_fks: dict[tuple[str, str, str], ForeignKeyField] = {}
-    for f in model._model_meta.local_fields:
+    for f in model._model_meta.fields:
         if isinstance(f, ForeignKeyField):
             to_table = f.target_field.model.model_options.db_table
             expected_fks[(f.column, to_table, f.target_field.column)] = f

--- a/plain-postgres/plain/postgres/fields/base.py
+++ b/plain-postgres/plain/postgres/fields/base.py
@@ -428,9 +428,7 @@ class Field[T](RegisterLookupMixin):
         # instance cheap to use beyond its primary key.
         if field_name not in data:
             missing = [
-                f.name
-                for f in instance._model_meta.concrete_fields
-                if f.name not in data
+                f.name for f in instance._model_meta.fields if f.name not in data
             ]
             instance.refresh_from_db(fields=missing)
 

--- a/plain-postgres/plain/postgres/forms.py
+++ b/plain-postgres/plain/postgres/forms.py
@@ -103,7 +103,7 @@ def model_to_dict(
 
     meta = instance._model_meta
     data = {}
-    for f in chain(meta.concrete_fields, meta.many_to_many):
+    for f in chain(meta.fields, meta.many_to_many):
         if fields is not None and f.name not in fields:
             continue
         value = f.value_from_object(instance)
@@ -138,9 +138,7 @@ def fields_for_model(
     ignored = []
     meta = model._model_meta
 
-    for f in sorted(
-        chain(meta.concrete_fields, meta.many_to_many), key=lambda f: f.name
-    ):
+    for f in sorted(chain(meta.fields, meta.many_to_many), key=lambda f: f.name):
         if fields is not None and f.name not in fields:
             continue
 

--- a/plain-postgres/plain/postgres/introspection/health/ownership.py
+++ b/plain-postgres/plain/postgres/introspection/health/ownership.py
@@ -29,7 +29,7 @@ def build_table_owners() -> dict[str, TableOwner]:
                 model_class=model.__name__,
                 model_file=_source_file(model),
             )
-            for field in model._model_meta.local_many_to_many:
+            for field in model._model_meta.many_to_many:
                 m2m_table = field.m2m_db_table()
                 if m2m_table in owners:
                     # Explicit "through" model already registered with its class.

--- a/plain-postgres/plain/postgres/meta.py
+++ b/plain-postgres/plain/postgres/meta.py
@@ -48,9 +48,7 @@ class Meta:
         {
             "fields",
             "many_to_many",
-            "concrete_fields",
-            "local_concrete_fields",
-            "_non_pk_concrete_field_names",
+            "_non_pk_field_names",
             "_forward_fields_map",
             "base_queryset",
         }
@@ -62,8 +60,10 @@ class Meta:
     model: type[Model]
     models_registry: Any
     _get_fields_cache: dict[Any, Any]
-    local_fields: list[ColumnField]
-    local_many_to_many: list[ManyToManyField]
+    # Mutable storage filled by add_field() while the model class is being
+    # built; read them through `fields` and `many_to_many`.
+    _fields: list[ColumnField]
+    _many_to_many: list[ManyToManyField]
 
     def __init__(self, models_registry: Any | None = None):
         """
@@ -111,8 +111,8 @@ class Meta:
         instance.model = model
         instance.models_registry = self._models_registry or default_models_registry
         instance._get_fields_cache = {}
-        instance.local_fields = []
-        instance.local_many_to_many = []
+        instance._fields = []
+        instance._many_to_many = []
 
         # Cache the instance BEFORE processing fields to prevent recursion
         self._cache[model] = instance
@@ -137,8 +137,8 @@ class Meta:
                     field.contribute_to_class(model, attr_name)
 
         # Sort fields: primary key first, then alphabetically by name
-        instance.local_fields.sort(key=lambda f: (not f.primary_key, f.name))
-        instance.local_many_to_many.sort(key=lambda f: f.name)
+        instance._fields.sort(key=lambda f: (not f.primary_key, f.name))
+        instance._many_to_many.sort(key=lambda f: f.name)
 
         return instance
 
@@ -164,9 +164,9 @@ class Meta:
         # two lists homogeneous is what lets the rest of the framework read
         # column attributes off `fields` without re-checking each one.
         if isinstance(field, ManyToManyField):
-            self.local_many_to_many.append(field)
+            self._many_to_many.append(field)
         elif isinstance(field, ColumnField):
-            self.local_fields.append(field)
+            self._fields.append(field)
         else:
             raise TypeError(f"{field!r} is neither a ColumnField nor a ManyToManyField")
 
@@ -190,60 +190,25 @@ class Meta:
     @cached_property
     def fields(self) -> ImmutableList[ColumnField]:
         """
-        Return a list of all column-backed forward fields on the model,
-        excluding ManyToManyFields.
+        All column-backed fields on the model, primary key first and then
+        sorted by name. ManyToManyFields live in `many_to_many`.
 
         Private API intended only to be used by Plain itself; get_fields()
         combined with filtering of field properties is the public API for
         obtaining this field list.
         """
-        return make_immutable_fields_list("fields", self.local_fields)
+        return make_immutable_fields_list("fields", self._fields)
 
     @cached_property
-    def concrete_fields(self) -> ImmutableList[ColumnField]:
+    def many_to_many(self) -> ImmutableList[ManyToManyField]:
         """
-        Return a list of all concrete fields on the model and its parents.
-
-        Private API intended only to be used by Plain itself; get_fields()
-        combined with filtering of field properties is the public API for
-        obtaining this field list.
-        """
-        return make_immutable_fields_list(
-            "concrete_fields", (f for f in self.fields if f.concrete)
-        )
-
-    @cached_property
-    def local_concrete_fields(self) -> ImmutableList[ColumnField]:
-        """
-        Return a list of all concrete fields on the model.
-
-        Private API intended only to be used by Plain itself; get_fields()
-        combined with filtering of field properties is the public API for
-        obtaining this field list.
-        """
-        return make_immutable_fields_list(
-            "local_concrete_fields", (f for f in self.local_fields if f.concrete)
-        )
-
-    @cached_property
-    def many_to_many(self) -> ImmutableList[Field]:
-        """
-        Return a list of all many to many fields on the model and its parents.
+        All ManyToManyFields on the model, sorted by name.
 
         Private API intended only to be used by Plain itself; get_fields()
         combined with filtering of field properties is the public API for
         obtaining this list.
         """
-        from plain.postgres.fields.related import ManyToManyField
-
-        return make_immutable_fields_list(
-            "many_to_many",
-            (
-                f
-                for f in self._get_fields(reverse=False)
-                if isinstance(f, ManyToManyField)
-            ),
-        )
+        return make_immutable_fields_list("many_to_many", self._many_to_many)
 
     @cached_property
     def related_objects(self) -> ImmutableList[ForeignObjectRel]:
@@ -497,8 +462,8 @@ class Meta:
                 collected.append(field.remote_field)
 
         if forward:
-            collected += self.local_fields
-            collected += self.local_many_to_many
+            collected += self._fields
+            collected += self._many_to_many
 
         # In order to avoid list manipulation. Always
         # return a shallow copy of the results
@@ -519,12 +484,12 @@ class Meta:
         return frozenset(names)
 
     @cached_property
-    def _non_pk_concrete_field_names(self) -> frozenset[str]:
+    def _non_pk_field_names(self) -> frozenset[str]:
         """
-        Return a set of the non-primary key concrete field names defined on the model.
+        Return a set of the non-primary key field names defined on the model.
         """
         names = []
-        for field in self.concrete_fields:
+        for field in self.fields:
             if not field.primary_key:
                 names.append(field.name)
         return frozenset(names)
@@ -566,6 +531,6 @@ class Meta:
 
         return {
             field.db_constraint_name(): field
-            for field in self.local_fields
+            for field in self.fields
             if isinstance(field, ForeignKeyField)
         }

--- a/plain-postgres/plain/postgres/migrations/state.py
+++ b/plain-postgres/plain/postgres/migrations/state.py
@@ -676,7 +676,7 @@ class ModelState:
         """Given a model, return a ModelState representing it."""
         # Deconstruct the fields
         fields = []
-        for field in model._model_meta.local_fields:
+        for field in model._model_meta.fields:
             if getattr(field, "remote_field", None) and exclude_rels:
                 continue
             name = field.name
@@ -688,7 +688,7 @@ class ModelState:
                     f"Couldn't reconstruct field {name} on {model.model_options.label}: {e}"
                 )
         if not exclude_rels:
-            for field in model._model_meta.local_many_to_many:
+            for field in model._model_meta.many_to_many:
                 name = field.name
                 assert name is not None
                 try:

--- a/plain-postgres/plain/postgres/preflight/indexes.py
+++ b/plain-postgres/plain/postgres/preflight/indexes.py
@@ -147,7 +147,7 @@ class CheckMissingFKIndexes(PreflightCheck):
         for model in _get_app_models():
             covered_fields = _fk_covered_field_names(model)
 
-            for field in model._model_meta.local_fields:
+            for field in model._model_meta.fields:
                 if (
                     isinstance(field, ForeignKeyField)
                     and not field.primary_key

--- a/plain-postgres/plain/postgres/query.py
+++ b/plain-postgres/plain/postgres/query.py
@@ -701,7 +701,7 @@ class QuerySet[T: "Model"]:
             update_fields_objs,
             unique_fields_objs,
         )
-        fields = meta.concrete_fields
+        fields = meta.fields
         self._prepare_for_bulk_create(objs)
         with transaction.atomic(savepoint=False):
             objs_with_id, objs_without_id = partition(lambda o: o.id is None, objs)
@@ -861,14 +861,14 @@ class QuerySet[T: "Model"]:
                 setattr(obj, k, v)
 
             update_fields = set(update_defaults)
-            concrete_field_names = self.model._model_meta._non_pk_concrete_field_names
-            # update_fields does not support non-concrete fields.
-            if concrete_field_names.issuperset(update_fields):
+            field_names = self.model._model_meta._non_pk_field_names
+            # update_fields only supports column-backed fields.
+            if field_names.issuperset(update_fields):
                 # Add fields which are set on pre_save(), e.g. update_now fields.
                 # This is to maintain backward compatibility as these fields
                 # are not updated unless explicitly specified in the
                 # update_fields list.
-                for field in self.model._model_meta.local_concrete_fields:
+                for field in self.model._model_meta.fields:
                     if not (
                         field.primary_key or field.__class__.pre_save is Field.pre_save
                     ):

--- a/plain-postgres/plain/postgres/schema.py
+++ b/plain-postgres/plain/postgres/schema.py
@@ -135,7 +135,7 @@ class DatabaseSchemaEditor:
         """Take a model and return its table definition."""
         column_sqls = []
         params = []
-        for field in model._model_meta.local_fields:
+        for field in model._model_meta.fields:
             definition, extra_params = self.column_sql(
                 model, field, include_default=field.has_persistent_column_default()
             )

--- a/plain-postgres/plain/postgres/sql/compiler.py
+++ b/plain-postgres/plain/postgres/sql/compiler.py
@@ -786,7 +786,7 @@ class SQLCompiler:
             opts = self.query.model._model_meta
         start_alias = start_alias or self.query.get_initial_alias()
 
-        for field in opts.concrete_fields:
+        for field in opts.fields:
             if select_mask and field not in select_mask:
                 continue
             result.append(field.get_col(start_alias))

--- a/plain-postgres/plain/postgres/sql/query.py
+++ b/plain-postgres/plain/postgres/sql/query.py
@@ -550,9 +550,7 @@ class Query(BaseExpression):
         if not (q.distinct and q.is_sliced):
             if q.group_by is True:
                 assert self.model is not None, "GROUP BY requires a model"
-                q.add_fields(
-                    (f.name for f in self.model._model_meta.concrete_fields), False
-                )
+                q.add_fields((f.name for f in self.model._model_meta.fields), False)
                 # Disable GROUP BY aliases to avoid orphaning references to the
                 # SELECT clause which is about to be cleared.
                 q.set_group_by(allow_aliases=False)
@@ -691,7 +689,7 @@ class Query(BaseExpression):
         # loaded. If a relational field is encountered it gets added to the
         # mask for it be considered if `select_related` and the cycle continues
         # by recursively calling this function.
-        for field in meta.concrete_fields:
+        for field in meta.fields:
             field_mask = mask.pop(field.name, None)
             if field_mask is None:
                 select_mask.setdefault(field, {})
@@ -2232,15 +2230,13 @@ class Query(BaseExpression):
             selected = frozenset(field_names + annotation_names)
         else:
             assert self.model is not None, "Default values query requires a model"
-            field_names = [f.name for f in self.model._model_meta.concrete_fields]
+            field_names = [f.name for f in self.model._model_meta.fields]
             selected = frozenset(field_names)
         # Selected annotations must be known before setting the GROUP BY
         # clause.
         if self.group_by is True:
             assert self.model is not None, "GROUP BY True requires a model"
-            self.add_fields(
-                (f.name for f in self.model._model_meta.concrete_fields), False
-            )
+            self.add_fields((f.name for f in self.model._model_meta.fields), False)
             # Disable GROUP BY aliases to avoid orphaning references to the
             # SELECT clause which is about to be cleared.
             self.set_group_by(allow_aliases=False)


### PR DESCRIPTION
Follow-up to #109.

`Meta` carried Django's field taxonomy, which distinguishes local vs. inherited fields (multi-table inheritance) and concrete vs. virtual fields (`GenericForeignKey` and friends). Plain has neither, so `fields`, `local_fields`, `concrete_fields`, and `local_concrete_fields` were four names for the same list, and `many_to_many` was the same as `local_many_to_many`. Every caller had to pick between synonyms, and that ambiguity is where the `Field.name` asserts in #103 and the `ColumnField` asserts in #109 came from.

- `Meta` now stores `_fields` and `_many_to_many` privately (filled by `add_field`, sorted once the class is built) and exposes exactly two forward collections: `fields` (`ImmutableList[ColumnField]`, primary key first then by name) and `many_to_many` (`ImmutableList[ManyToManyField]`, by name). `related_objects` and `get_fields(include_reverse=)` are unchanged.
- Deleted `local_fields`, `concrete_fields`, `local_concrete_fields`, and `local_many_to_many`, and renamed every call site (about 50, all in plain-postgres).
- `many_to_many` is now typed as `ManyToManyField` rather than `Field`, and builds from storage instead of filtering `_get_fields()`.
- `_check_local_fields` is now `_check_referenced_fields`, and its "field is not local to this model" branch is gone: a forward field is always either in `fields` or a `ManyToManyField`, and the M2M case is already reported just above it.
- `_non_pk_concrete_field_names` is now `_non_pk_field_names`.

Left alone on purpose: the `Field.concrete` attribute. It is `True` for every field (M2M included, since M2M doesn't clear `column`) and only `False` on `ForeignObjectRel`, so it's a candidate for the same treatment, but it's read in a few places outside `Meta` and deserves its own look.

No public docs reference the removed names.

## Test plan

- [x] `./scripts/type-validate` 26/26
- [x] `./scripts/test` across all packages