### PR TITLE
Block scheme-prefixed redirect URLs without slashes

### DIFF
--- a/plain/plain/http/response.py
+++ b/plain/plain/http/response.py
@@ -703,6 +703,10 @@ class FileResponse(StreamingResponse):
             self.headers["Content-Disposition"] = content_disposition
 
 
+# A URI scheme per RFC 3986: a letter, then letters, digits, "+", "-", ".".
+_SCHEME_PREFIX_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*:")
+
+
 def _is_external_url(url: str) -> bool:
     """Check if a URL would redirect to an external host."""
     if not url:
@@ -713,8 +717,10 @@ def _is_external_url(url: str) -> bool:
     # so \\ and /\ are equivalent to //
     if url[:2].replace("\\", "/") == "//":
         return True
-    colon_pos = url.find("://")
-    return colon_pos > 0 and url[:colon_pos].isalpha()
+    # Any scheme sends the browser off this origin, with or without "//"
+    # after it. Browsers normalize "http:/evil.com" (a single slash) to
+    # "http://evil.com", so matching on "://" alone lets that through.
+    return _SCHEME_PREFIX_RE.match(url) is not None
 
 
 class RedirectResponse(Response):

--- a/plain/tests/public/test_safe_redirect.py
+++ b/plain/tests/public/test_safe_redirect.py
@@ -24,6 +24,18 @@ class TestRedirectResponse:
     @pytest.mark.parametrize(
         "url",
         [
+            "/orders/2024-01-01:summary",  # colon later in the path
+            "?next=https://evil.com",  # colon inside a query value
+            "#section:one",  # colon inside a fragment
+            "2fa:setup",  # not a scheme — schemes must start with a letter
+        ],
+    )
+    def test_internal_url_containing_colon_allowed(self, url):
+        assert RedirectResponse(url, status_code=302).url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
             "https://evil.com",
             "http://evil.com",
             "ftp://evil.com",
@@ -35,6 +47,16 @@ class TestRedirectResponse:
             "\thttps://evil.com",  # leading tab bypass
             "\n//evil.com",  # leading newline bypass
             "HtTpS://evil.com",  # mixed-case scheme
+            # A scheme with a single slash: browsers normalize "http:/evil.com"
+            # to "http://evil.com", so these leave the origin too.
+            "http:/evil.com",
+            "https:/evil.com",
+            "http:evil.com",  # scheme with no slashes at all
+            # Schemes that never stay on this origin, whatever the browser
+            # does with them.
+            "javascript:alert(1)",
+            "data:text/html,<h1>x",
+            "view-source:https://evil.com",  # non-alpha scheme characters
         ],
     )
     def test_external_url_rejected_by_default(self, url):


### PR DESCRIPTION
`_is_external_url` detected external redirect targets by searching for a literal `://`. A URL with a scheme and a single slash never matched, so it passed the guard and went into the `Location` header verbatim:

```
GET /login?next=http:/evil.com   ->   302  Location: http:/evil.com
```

Browsers normalize `http:/evil.com` to `http://evil.com`, so that's a working open redirect anywhere user input reaches `RedirectResponse` — a `?next=` parameter being the obvious case. Django guards this exact shape (`if not url_info.netloc and url_info.scheme: return False`), with a comment naming Chrome's normalization.

### Fix

Match an RFC 3986 scheme prefix instead of `://`. That also covers:

- `http:evil.com` — scheme with no slashes at all
- `view-source:`, and other schemes containing non-alpha characters
- `javascript:` and `data:`, which previously passed the guard and relied on the browser refusing them in a `Location` header

Internal URLs that merely contain a colon are unaffected, since a scheme has to start the string and begin with a letter — `/orders/2024-01-01:summary`, `?next=…`, and `2fa:setup` all still redirect fine.

### Verification

| `next=` | Before | After |
|---|---|---|
| `https://evil.com` | blocked | blocked |
| `http:/evil.com` | **`Location: http:/evil.com`** | blocked |
| `https:/evil.com` | **`Location: https:/evil.com`** | blocked |

The "before" column was measured end-to-end through `plain.test.Client` against a logged-in user hitting `/login?next=…`.

`test_safe_redirect.py` goes from 24 to 35 cases, covering the single-slash, no-slash, and non-alpha-scheme shapes plus internal URLs containing colons. Full suite green across all 26 packages; lint and type-check clean.
