### PR TITLE
Document login links as reusable until expiry

### DIFF
--- a/plain-loginlink/plain/loginlink/README.md
+++ b/plain-loginlink/plain/loginlink/README.md
@@ -15,7 +15,7 @@
 
 Login links let users authenticate by clicking a link sent to their email address, instead of entering a password. This approach is often called "magic links" and provides a simple, secure authentication experience.
 
-When a user enters their email address, they receive an email with a one-time login link. Clicking the link logs them in automatically. The links are cryptographically signed and include an expiration time for security.
+When a user enters their email address, they receive an email with a login link. Clicking the link logs them in automatically. The links are cryptographically signed and carry an embedded expiration, and they keep working until that expiration passes.
 
 ```python
 # app/urls.py
@@ -104,7 +104,7 @@ See [plain.email](/plain-email/plain/email/README.md) for more details on email 
 
 ## Customizing link expiration
 
-By default, login links expire after 1 hour (3600 seconds). You can change this by overriding the form's `maybe_send_link` call:
+By default, login links expire after 1 hour (3600 seconds). Change it by setting [`link_expires_in`](./forms.py#LoginLinkForm) on the form:
 
 ```python
 from plain.loginlink.views import LoginLinkFormView
@@ -112,13 +112,14 @@ from plain.loginlink.forms import LoginLinkForm
 
 
 class CustomLoginLinkForm(LoginLinkForm):
-    def maybe_send_link(self, request, expires_in=60 * 15):  # 15 minutes
-        return super().maybe_send_link(request, expires_in=expires_in)
+    link_expires_in = 60 * 15  # 15 minutes
 
 
 class CustomLoginView(LoginLinkFormView):
     form_class = CustomLoginLinkForm
 ```
+
+A link works for this entire window, not just once (see [Are login links single-use?](#are-login-links-single-use)), so choose a duration you're comfortable handing out for that long. Very short windows fail in practice — corporate mail can take minutes to deliver, and users get distracted mid-signup.
 
 ## Generating links manually
 
@@ -167,6 +168,18 @@ def validate_token(token):
 #### What happens if the email doesn't match any user?
 
 The form still redirects to the "sent" page without revealing whether the email exists. This prevents account enumeration attacks.
+
+#### Are login links single-use?
+
+No. A link works every time it is clicked until it expires. The security boundary is the expiration window, not consuming the link.
+
+This is a deliberate choice. Anyone who can read the inbox can request a fresh link, so a compromised inbox is equally exposed either way — single-use only covers a link that escaped the inbox, was already used, and is still unexpired. Against that narrow gain, marking a link spent on the first request breaks with corporate mail security (Safe Links, Mimecast, Barracuda), which fetches URLs in incoming email and would spend the link before the recipient ever clicks. Avoiding that means landing on a confirmation page and asking every user to click a button to finish signing in.
+
+Set an expiration you are comfortable handing out for that whole window. See [Customizing link expiration](#customizing-link-expiration).
+
+If you need single-use links, build the flow you want on top of [`plain.signing`](/plain/plain/signing.py) rather than reaching for a hook here. `TimestampSigner` covers the token half — [plain.passwords](/plain-passwords/plain/passwords/README.md) signs its reset tokens that way. The other half is storage, since marking a link spent means recording the ones you issued, and where that lives depends on what else you want from it — revocation, an audit trail, per-device rules.
+
+Note that the session created by a login link long outlives the link. Session lifetime and revocation belong to [plain.sessions](/plain-sessions/plain/sessions/README.md).
 
 #### Can I use this alongside password authentication?
 

--- a/plain-loginlink/plain/loginlink/forms.py
+++ b/plain-loginlink/plain/loginlink/forms.py
@@ -17,9 +17,12 @@ class LoginLinkForm(forms.Form):
     email = forms.EmailField()
     next = forms.TextField(required=False)
 
-    def maybe_send_link(
-        self, request: Request, expires_in: int = 60 * 60
-    ) -> int | None:
+    # How long a link stays valid, in seconds. Links work for this entire
+    # window, so pick a duration you're comfortable handing out.
+    link_expires_in: int = 60 * 60
+
+    def maybe_send_link(self, request: Request) -> int | None:
+        expires_in = self.link_expires_in
         email = self.cleaned_data["email"]
         try:
             user = User.query.get(email__iexact=email)

--- a/plain-loginlink/tests/app/urls.py
+++ b/plain-loginlink/tests/app/urls.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from plain.auth.views import AuthView
 from plain.http import Response
+from plain.loginlink.forms import LoginLinkForm
 from plain.loginlink.urls import LoginlinkRouter
 from plain.loginlink.views import LoginLinkFormView
 from plain.urls import Router, include, path
@@ -17,6 +18,17 @@ from plain.views import View
 
 class LoginView(LoginLinkFormView):
     template_name = "loginlinkform.html"
+
+
+class AlreadyExpiredForm(LoginLinkForm):
+    """Mints links that are past their expiration the moment they're sent."""
+
+    link_expires_in = -3600
+
+
+class AlreadyExpiredLoginView(LoginLinkFormView):
+    template_name = "loginlinkform.html"
+    form_class = AlreadyExpiredForm
 
 
 class IndexView(View):
@@ -39,6 +51,11 @@ class AppRouter(Router):
     namespace = ""
     urls = (
         path("login", LoginView, name="login"),
+        path(
+            "login-already-expired",
+            AlreadyExpiredLoginView,
+            name="login-already-expired",
+        ),
         include("loginlink", LoginlinkRouter),
         path("whoami", WhoamiView, name="whoami"),
         path("", IndexView, name="index"),

--- a/plain-loginlink/tests/public/test_loginlink.py
+++ b/plain-loginlink/tests/public/test_loginlink.py
@@ -61,6 +61,23 @@ class TestRequestLink:
         assert len(mailoutbox) == 0
 
 
+class TestLinkExpiration:
+    def test_form_link_expires_in_is_honored(self, db, mailoutbox):
+        """A form's `link_expires_in` sets the window on the links it sends."""
+        User.query.create(email="shortlived@example.com")
+        client = Client()
+
+        client.post(
+            "/login-already-expired",
+            data={"email": "shortlived@example.com", "next": ""},
+        )
+
+        response = client.get(token_path(mailoutbox[0]), follow=True)
+
+        assert "Link Expired" in response.content.decode()
+        assert not is_logged_in(client)
+
+
 class TestAlreadyLoggedIn:
     def test_login_page_redirects_home(self, db):
         client = Client()


### PR DESCRIPTION
The README said users "receive an email with a one-time login link." That was never true. `generate_link_url` signs `{user_id, email}` with an embedded expiry and nothing else, and `get_link_token_user` only verifies the HMAC — nothing records that a link was used, so a link works every time it's clicked until it expires.

That's a claim someone could build a security model on, so this replaces it with the actual semantics and an FAQ explaining why reusable-until-expiry is the deliberate choice:

- Anyone who can read the inbox can request a fresh link, so a compromised inbox is equally exposed either way.
- Marking a link spent on first request breaks with corporate mail security (Safe Links, Mimecast, Barracuda), which fetches URLs in incoming mail and would spend the link before the recipient ever clicks. Avoiding that means a confirmation page and a click for every user — the mainstream approach, named in the FAQ with its real cost.
- The session a link creates long outlives the link, so session lifetime and revocation belong to `plain.sessions`.

The FAQ points anyone who needs single-use links at core `plain.signing`, with `plain.passwords` reset tokens as the in-repo precedent, rather than at loginlink internals.

### `link_expires_in`

Expiration was a default argument on `maybe_send_link`, so changing it meant overriding a method purely to pass a different number through:

```python
class CustomLoginLinkForm(LoginLinkForm):
    def maybe_send_link(self, request, expires_in=60 * 15):
        return super().maybe_send_link(request, expires_in=expires_in)
```

It's now a `link_expires_in` class attribute — one line on a subclass. The default is unchanged at 1 hour. `generate_link_url` keeps its explicit `expires_in` parameter, so the low-level helper stays explicit while the high-level form is configured.

Because the deadline is embedded in the token, validation stays parameterless (`get_link_token_user` can't know which window the issuer picked) — and lowering `link_expires_in` doesn't shorten links already sitting in inboxes.

### Tests

New contract test that a form's `link_expires_in` sets the window on the links it sends, driven end-to-end through a test-app login view. 11 tests, up from 10.
