### PR TITLE
Remove Field.concrete

### DIFF
--- a/plain-admin/plain/admin/views/models.py
+++ b/plain-admin/plain/admin/views/models.py
@@ -234,7 +234,7 @@ class AdminModelDetailView(AdminDetailView):
         if fields := super().get_fields():
             return fields
 
-        return tuple(f.name for f in self.object._model_meta.get_fields() if f.concrete)
+        return tuple(f.name for f in self.object._model_meta.get_fields())
 
     def get_field_value(self, obj: Any, field: str) -> Any:
         try:

--- a/plain-postgres/plain/postgres/base.py
+++ b/plain-postgres/plain/postgres/base.py
@@ -123,9 +123,6 @@ class Model(metaclass=ModelBase):
             from plain.postgres.fields.related import RelatedField
 
             is_related_object = False
-            # Virtual field
-            if field.name not in kwargs and field.column is None:
-                continue
             if isinstance(field, RelatedField) and isinstance(
                 field.remote_field, ForeignObjectRel
             ):
@@ -395,8 +392,8 @@ class Model(metaclass=ModelBase):
             non_model_fields = fields.difference(field_names)
             if non_model_fields:
                 raise ValueError(
-                    "The following fields do not exist in this model, are m2m "
-                    "fields, or are non-concrete fields: "
+                    "The following fields do not exist in this model or are m2m "
+                    "fields: "
                     f"{', '.join(sorted(non_model_fields))}"
                 )
             deferred_in_update = fields & deferred_fields

--- a/plain-postgres/plain/postgres/fields/base.py
+++ b/plain-postgres/plain/postgres/fields/base.py
@@ -115,7 +115,6 @@ class Field[T](RegisterLookupMixin):
     name: str
     # Set by set_attributes_from_name (called by contribute_to_class)
     column: str
-    concrete: bool
     # Set by contribute_to_class
     model: type[Model]
 
@@ -376,7 +375,6 @@ class Field[T](RegisterLookupMixin):
         # The database column is the field name. A foreign key overrides this
         # method only to append the "_id" suffix to `column`.
         self.column = self.name
-        self.concrete = self.column is not None
 
     def contribute_to_class(self, cls: type[Model], name: str) -> None:
         """

--- a/plain-postgres/plain/postgres/fields/reverse_related.py
+++ b/plain-postgres/plain/postgres/fields/reverse_related.py
@@ -41,7 +41,6 @@ class ForeignObjectRel(FieldCacheMixin):
 
     # Field flags
     auto_created = True
-    concrete = False
 
     # Reverse relations are always nullable (Plain can't enforce that a
     # foreign key on the related model points to this model).

--- a/plain-postgres/plain/postgres/query.py
+++ b/plain-postgres/plain/postgres/query.py
@@ -638,14 +638,12 @@ class QuerySet[T: "Model"]:
                 raise ValueError(
                     "Unique fields that can trigger the upsert must be provided."
                 )
-            # Updating primary keys and non-concrete fields is forbidden.
+            # Updating primary keys and many-to-many fields is forbidden.
             from plain.postgres.fields.related import ManyToManyField
 
-            if any(
-                not f.concrete or isinstance(f, ManyToManyField) for f in update_fields
-            ):
+            if any(isinstance(f, ManyToManyField) for f in update_fields):
                 raise ValueError(
-                    "bulk_create() can only be used with concrete fields in "
+                    "bulk_create() cannot be used with many-to-many fields in "
                     "update_fields."
                 )
             if any(f.primary_key for f in update_fields):
@@ -655,12 +653,9 @@ class QuerySet[T: "Model"]:
             if unique_fields:
                 from plain.postgres.fields.related import ManyToManyField
 
-                if any(
-                    not f.concrete or isinstance(f, ManyToManyField)
-                    for f in unique_fields
-                ):
+                if any(isinstance(f, ManyToManyField) for f in unique_fields):
                     raise ValueError(
-                        "bulk_create() can only be used with concrete fields "
+                        "bulk_create() cannot be used with many-to-many fields "
                         "in unique_fields."
                     )
             return OnConflict.UPDATE
@@ -758,8 +753,8 @@ class QuerySet[T: "Model"]:
         ]
         from plain.postgres.fields.related import ManyToManyField
 
-        if any(not f.concrete or isinstance(f, ManyToManyField) for f in fields_list):
-            raise ValueError("bulk_update() can only be used with concrete fields.")
+        if any(isinstance(f, ManyToManyField) for f in fields_list):
+            raise ValueError("bulk_update() cannot be used with many-to-many fields.")
         if any(f.primary_key for f in fields_list):
             raise ValueError("bulk_update() cannot be used with primary key fields.")
         if not objs_tuple:


### PR DESCRIPTION
Follow-up to #111.

`Field.concrete` was `self.column is not None`, and `column` is always set from the field name, so it was `True` on every field, many-to-many included. The only `False` was a class attribute on `ForeignObjectRel`, which isn't a field. It was the last piece of Django's concrete-vs-virtual field distinction that #111 removed from `Meta`.

- Drop the attribute from `Field` and `ForeignObjectRel`.
- The three `bulk_create()` / `bulk_update()` guards that read `not f.concrete or isinstance(f, ManyToManyField)` now check only for `ManyToManyField`, which is the case they were ever catching. Error messages say "many-to-many fields" instead of "concrete fields".
- The admin detail view's field list filtered `get_fields()` on `concrete`, which excluded nothing; the filter is gone and the result is unchanged.
- `Model.__init__` had a "virtual field" skip keyed on `field.column is None`, which was unreachable for the same reason.

## Test plan

- [x] `plain-code check` clean
- [x] `./scripts/type-validate` 26/26
- [x] `./scripts/test` across all packages