### PR TITLE
Fix QuerySet.ordered and replace unresolved-attribute ignores with narrowing

### DIFF
--- a/plain-admin/plain/admin/views/models.py
+++ b/plain-admin/plain/admin/views/models.py
@@ -136,11 +136,11 @@ class AdminModelListView(AdminListView):
         # the queryset lazy. Coerce each id through the pk field and drop the
         # ones it rejects, so a stale or malformed id is ignored (per the base
         # contract) rather than raising.
-        pk_field = self.model._model_meta.get_field("id")
+        pk_field = self.model._model_meta.get_forward_field("id")
         valid_ids = []
         for raw_id in ids:
             try:
-                valid_ids.append(pk_field.to_python(raw_id))  # ty: ignore[unresolved-attribute]
+                valid_ids.append(pk_field.to_python(raw_id))
             except ValidationError:
                 continue
         return objects.filter(id__in=valid_ids)

--- a/plain-passwords/plain/passwords/forms.py
+++ b/plain-passwords/plain/passwords/forms.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from app.users.models import User
 from plain.exceptions import ValidationError
+from plain.postgres.fields.base import ColumnField
 from plain.postgres.forms import ModelForm
 
 from plain import forms
@@ -103,7 +104,12 @@ class PasswordSetForm(forms.Form):
         assert isinstance(password2, str), "new_password2 must be a string"
 
         # Clean it as if it were being put into the model directly
-        self.user._model_meta.get_field("password").clean(password2, self.user)  # ty: ignore[unresolved-attribute]
+        password_field = self.user._model_meta.get_forward_field("password")
+        if not isinstance(password_field, ColumnField):
+            raise TypeError(
+                f"{type(self.user).__name__}.password must be a column field"
+            )
+        password_field.clean(password2, self.user)
 
         return password2
 

--- a/plain-postgres/plain/postgres/base.py
+++ b/plain-postgres/plain/postgres/base.py
@@ -1036,7 +1036,11 @@ class Model(metaclass=ModelBase):
             fld = None
             for part in field.split(LOOKUP_SEP):
                 try:
-                    fld = _cls._model_meta.get_field(part)  # ty: ignore[unresolved-attribute]
+                    if _cls is None:
+                        # The previous part was not a relation, so there is
+                        # no model left to look the next part up on.
+                        raise FieldDoesNotExist(part)
+                    fld = _cls._model_meta.get_field(part)
                     if isinstance(fld, RelatedField):
                         _cls = fld.path_infos[-1].to_meta.model
                     else:

--- a/plain-postgres/plain/postgres/migrations/graph.py
+++ b/plain-postgres/plain/postgres/migrations/graph.py
@@ -358,7 +358,13 @@ class MigrationGraph:
         plan = self._generate_plan(nodes, at_end)
         project_state = ProjectState(real_packages=real_packages)
         for node in plan:
-            project_state = self.nodes[node].mutate_state(project_state, preserve=False)  # ty: ignore[unresolved-attribute]
+            migration = self.nodes[node]
+            if migration is None:
+                raise NodeNotFoundError(
+                    f"Migration {node} is a placeholder with no migration to apply",
+                    node,
+                )
+            project_state = migration.mutate_state(project_state, preserve=False)
         return project_state
 
     def __contains__(self, node: tuple[str, str]) -> bool:

--- a/plain-postgres/plain/postgres/migrations/state.py
+++ b/plain-postgres/plain/postgres/migrations/state.py
@@ -174,8 +174,8 @@ class ProjectState:
             if reference.through:
                 if changed_field is None:
                     changed_field = field.clone()
-                assert changed_field.remote_field is not None
-                changed_field.remote_field.through_ref = new_remote_model  # ty: ignore[unresolved-attribute]
+                assert isinstance(changed_field.remote_field, ManyToManyRel)
+                changed_field.remote_field.through_ref = new_remote_model
             if changed_field:
                 model_state.fields[name] = changed_field
                 to_reload.add((model_state.package_label, model_state.name_lower))

--- a/plain-postgres/plain/postgres/query.py
+++ b/plain-postgres/plain/postgres/query.py
@@ -1335,7 +1335,7 @@ class QuerySet[T: "Model"]:
             or (
                 self.sql_query.default_ordering
                 and self.sql_query.model
-                and self.sql_query.model._model_meta.ordering  # ty: ignore[unresolved-attribute]
+                and self.sql_query.model.model_options.ordering
                 and
                 # A default ordering doesn't affect GROUP BY queries.
                 not self.sql_query.group_by

--- a/plain-postgres/tests/public/test_queryset_ordered.py
+++ b/plain-postgres/tests/public/test_queryset_ordered.py
@@ -1,0 +1,14 @@
+from app.examples.models.mixins import MixinTestModel
+from app.examples.models.relationships import Tag
+
+
+def test_ordered_reflects_model_default_ordering():
+    """`QuerySet.ordered` is True when the model declares a default ordering."""
+    assert MixinTestModel.model_options.ordering
+    assert MixinTestModel.query.all().ordered is True
+
+
+def test_ordered_reflects_explicit_order_by():
+    assert not Tag.model_options.ordering
+    assert Tag.query.all().ordered is False
+    assert Tag.query.order_by("name").ordered is True

--- a/plain/plain/http/multipartparser.py
+++ b/plain/plain/http/multipartparser.py
@@ -407,8 +407,9 @@ class MultiPartParser:
         # We should document that...
         # (Maybe add handler.free_file to complement new_file)
         for handler in self._upload_handlers:
-            if hasattr(handler, "file"):
-                handler.file.close()  # ty: ignore[unresolved-attribute]
+            file = getattr(handler, "file", None)
+            if file is not None:
+                file.close()
 
 
 class LazyStream:


### PR DESCRIPTION
A sweep of the `ty: ignore[unresolved-attribute]` comments in library code. I stripped every one, let ty report what each was hiding, and fixed the ones that were hiding something real or that a proper narrowing resolves. The rest are put back with the same comments.

## A real bug: `QuerySet.ordered` always crashed

`QuerySet.ordered` read `self.sql_query.model._model_meta.ordering`, but `ordering` lives on `model_options`, not `Meta`. Any call raised `AttributeError`. Nothing in the framework calls it, which is how it survived, but it's a public property. Fixed, with a public test.

## Narrowing fixes

- `plain-admin` bulk-action id coercion and `plain-passwords` password cleaning used `get_field()`, which returns `Field | ForeignObjectRel`; both now use `get_forward_field()`, and the password check narrows to `ColumnField` before calling `clean()`.
- `Model._check_ordering` relied on catching `AttributeError` from `None._model_meta` to stop walking a lookup path past a non-relation. It now raises `FieldDoesNotExist` explicitly at that point, which the same `except` already handles.
- `MigrationGraph.make_state` indexed `self.nodes[node]`, which can be `None` for a placeholder node, and called through it. It now raises `NodeNotFoundError` with the node name instead.
- `ProjectState.rename_model` asserts the rel is a `ManyToManyRel` before writing `through_ref`, in place of the weaker `is not None` assert.
- `MultiPartParser._close_files` uses `getattr(handler, "file", None)` instead of `hasattr` plus an attribute read.

## Kept, with their existing comments

These are honest limitations of the type checker rather than something the code is doing wrong: decorators that stamp attributes onto functions (`plain.cli.runtime`, `plain.api.openapi`), `super()` calls inside mixins that don't declare their host class (`PageViewMixin`, `SessionView`, `EncryptedFieldMixin`, the integer lookup mixins), `ProcessPoolExecutor._max_workers`, Windows-only `ctypes.windll`, name-mangled `__cast`, `__safe_for_unpickle__`, and the `ChoicesMeta` iteration helpers. The six in `AdminViewset.get_views()` stamp one view class's classmethod onto its siblings as instance-method replacements; that deserves its own look rather than a typing patch.

Type ignores 138 → 131.

## Test plan

- [x] `plain-code check` clean
- [x] `./scripts/type-validate` 26/26
- [x] `./scripts/test` across all packages