### PR TITLE
Make OrderBy.asc/desc return the OrderBy and stop UUIDField subclassing TextField

### DIFF
--- a/plain-postgres/plain/postgres/expressions.py
+++ b/plain-postgres/plain/postgres/expressions.py
@@ -1698,11 +1698,23 @@ class OrderBy(Expression):
             self.nulls_last = None
         return self
 
-    def asc(self) -> None:  # ty: ignore[invalid-method-override]
+    def asc(self, **kwargs: Any) -> OrderBy:
+        if kwargs:
+            raise TypeError(
+                "OrderBy.asc() takes no options; set nulls_first/nulls_last on "
+                "the OrderBy itself."
+            )
         self.descending = False
+        return self
 
-    def desc(self) -> None:  # ty: ignore[invalid-method-override]
+    def desc(self, **kwargs: Any) -> OrderBy:
+        if kwargs:
+            raise TypeError(
+                "OrderBy.desc() takes no options; set nulls_first/nulls_last on "
+                "the OrderBy itself."
+            )
         self.descending = True
+        return self
 
 
 class Window(Expression):

--- a/plain/plain/forms/fields.py
+++ b/plain/plain/forms/fields.py
@@ -1081,7 +1081,7 @@ class MultipleChoiceField(ChoiceField):
         return data.getlist(html_name)
 
 
-class UUIDField(TextField):
+class UUIDField(Field):
     default_error_messages: ClassVar = {
         "invalid": "Enter a valid UUID.",
     }
@@ -1091,16 +1091,15 @@ class UUIDField(TextField):
             return str(value)
         return value
 
-    def to_python(self, value: Any) -> uuid.UUID | None:  # ty: ignore[invalid-method-override]
-        value = super().to_python(value)
+    def to_python(self, value: Any) -> uuid.UUID | None:
         if value in self.empty_values:
             return None
-        if not isinstance(value, uuid.UUID):
-            try:
-                value = uuid.UUID(value)
-            except ValueError:
-                raise ValidationError(self.error_messages["invalid"], code="invalid")
-        return value
+        if isinstance(value, uuid.UUID):
+            return value
+        try:
+            return uuid.UUID(str(value).strip())
+        except ValueError:
+            raise ValidationError(self.error_messages["invalid"], code="invalid")
 
 
 class InvalidJSONInput(str):


### PR DESCRIPTION
Two of the `invalid-method-override` ignores were hiding overrides that returned the wrong thing.

- **`OrderBy.asc()` / `desc()` returned `None`** where `Expression.asc()` / `desc()` return an `OrderBy`. Both callers in the compiler guard with `isinstance(..., OrderBy)` first so nothing was assigning `None`, but the signature was a lie. They now flip `descending` and return `self`, and reject the `nulls_first` / `nulls_last` options that `Expression.asc()` accepts, since an `OrderBy` already carries those.
- **`forms.UUIDField` subclassed `TextField`** and returned a `UUID` from `to_python()` where `TextField` promises `str`. It used nothing from `TextField` beyond a `strip()`, so it now subclasses `Field` directly and strips inline. This drops the `max_length` / `min_length` / `strip` / `empty_value` constructor arguments, which never made sense for a UUID.

The remaining `to_python` override ignores (`NullBooleanField`, `MultipleChoiceField`, `ModelMultipleChoiceField`) are the same shape but the subclasses genuinely reuse their base's form-data handling or choices machinery, so untangling them is a hierarchy change rather than a signature fix. Left as-is.

Type ignores 138 → 135 (relative to master at branch time).

## Test plan

- [x] `plain-code check` clean
- [x] `./scripts/type-validate` 26/26
- [x] `./scripts/test` across all packages